### PR TITLE
Update tests to work offline

### DIFF
--- a/stix2validator/musts.py
+++ b/stix2validator/musts.py
@@ -5,6 +5,7 @@ import re
 from . import enums
 from .util import cyber_observable_check, has_cyber_observable_data
 from .errors import JSONError
+from .output import info
 
 
 def modified_created(instance):
@@ -211,6 +212,16 @@ def artifact_mime_type(instance):
                                     "Type of the form 'type/subtype'."
                                     % (key, obj['mime_type']), instance['id'])
 
+            else:
+                info("Can't reach IANA website; using regex for mime types.")
+                mime_pattern = '^(application|audio|font|image|message|model' \
+                               '|multipart|text|video)/[a-zA-Z0-9.+_-]+'
+                if not re.match(mime_pattern, obj['mime_type']):
+                    yield JSONError("The 'mime_type' property of object '%s' "
+                                    "('%s') should be an IANA MIME Type of the"
+                                    " form 'type/subtype'."
+                                    % (key, obj['mime_type']), instance['id'])
+
 
 @cyber_observable_check
 def character_set(instance):
@@ -225,10 +236,26 @@ def character_set(instance):
                                     "('%s') must be an IANA registered "
                                     "character set."
                                     % (key, obj['path_enc']), instance['id'])
+            else:
+                info("Can't reach IANA website; using regex for character_set.")
+                char_pattern = '^[a-zA-Z0-9_\(\)-]+$'
+                if not re.match(char_pattern, obj['path_enc']):
+                    yield JSONError("The 'path_enc' property of object '%s' "
+                                    "('%s') must be an IANA registered "
+                                    "character set."
+                                    % (key, obj['path_enc']), instance['id'])
 
         if ('type' in obj and obj['type'] == 'file' and 'name_enc' in obj):
             if enums.char_sets():
                 if obj['name_enc'] not in enums.char_sets():
+                    yield JSONError("The 'name_enc' property of object '%s' "
+                                    "('%s') must be an IANA registered "
+                                    "character set."
+                                    % (key, obj['name_enc']), instance['id'])
+            else:
+                info("Can't reach IANA website; using regex for character_set.")
+                char_pattern = '^[a-zA-Z0-9_\(\)-]+$'
+                if not re.match(char_pattern, obj['name_enc']):
                     yield JSONError("The 'name_enc' property of object '%s' "
                                     "('%s') must be an IANA registered "
                                     "character set."

--- a/stix2validator/shoulds.py
+++ b/stix2validator/shoulds.py
@@ -756,7 +756,7 @@ def protocols(instance):
                                         'protocols')
                 else:
                     info("Can't reach IANA website; using regex for protocols.")
-                    prot_pattern = '^[a-zA-Z0-9-]{1,15}'
+                    prot_pattern = '^[a-zA-Z0-9-]{1,15}$'
                     if not re.match(prot_pattern, prot):
                         yield JSONError("The 'protocols' property of object "
                                         "'%s' contains a value ('%s') not in "

--- a/stix2validator/test/network_traffic_tests.py
+++ b/stix2validator/test/network_traffic_tests.py
@@ -78,7 +78,7 @@ class ObservedDataTestCases(ValidatorTest):
 
     def test_network_traffic_protocols(self):
         net_traffic = copy.deepcopy(self.valid_net_traffic)
-        net_traffic['objects']['1']['protocols'].append('foobar')
+        net_traffic['objects']['1']['protocols'].append('foo_bar')
         self.assertFalseWithOptions(json.dumps(net_traffic))
         self.check_ignore(json.dumps(net_traffic), 'protocols')
 
@@ -90,7 +90,7 @@ class ObservedDataTestCases(ValidatorTest):
         net_traffic['objects']['1']['ipfix'] = {
             "minimumIpTotalLength": 32,
             "maximumIpTotalLength": 2556,
-            "foo": "bar"
+            "Foo": "bar"
         }
         self.assertFalseWithOptions(json.dumps(net_traffic))
         self.check_ignore(json.dumps(net_traffic), 'ipfix')

--- a/stix2validator/test/observed_data_tests.py
+++ b/stix2validator/test/observed_data_tests.py
@@ -502,7 +502,7 @@ class ObservedDataTestCases(ValidatorTest):
 
     def test_file_character_set(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
-        observed_data['objects']['0']['name_enc'] = "blablabla"
+        observed_data['objects']['0']['name_enc'] = "bla.bla.bla"
         self.assertFalseWithOptions(json.dumps(observed_data))
 
         observed_data['objects']['0']['name_enc'] = "ISO-8859-2"
@@ -513,7 +513,7 @@ class ObservedDataTestCases(ValidatorTest):
         observed_data['objects']['2'] = {
           "type": "directory",
           "path": "C:\\Windows\\System32",
-          "path_enc": "blablabla"
+          "path_enc": "bla.bla.bla"
         }
         self.assertFalseWithOptions(json.dumps(observed_data))
 


### PR DESCRIPTION
Fix #12.

STIX content that passes validation when the cache is used may fail validation when the cache is not used, because in the latter case a regex is used instead of checking a list. Values not in the list may still match the regex.