### PR TITLE
Miscellaneous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ lib
 lib64
 __pycache__
 .cache
+.coverage
+htmlcov
 
 # Operating System
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ install_requires = [
     'colorama',
     'six',
     'requests',
-    'requests_cache'
+    'requests_cache',
+    'stix2-patterns'
 ]
 
 setup(

--- a/stix2validator/enums.py
+++ b/stix2validator/enums.py
@@ -1276,7 +1276,6 @@ VOCAB_PROPERTIES = {
     "threat-actor": [
         'labels',
         'roles',
-        'goals',
         'sophistication',
         'resource_level',
         'primary_motivation',

--- a/stix2validator/enums.py
+++ b/stix2validator/enums.py
@@ -1137,7 +1137,11 @@ RESERVED_PROPERTIES = [
     'action',
     'usernames',
     'phone_numbers',
-    'addresses'
+    'addresses',
+    'first_seen_precision',
+    'last_seen_precision',
+    'valid_from_precision',
+    'valid_until_precision'
 ]
 RESERVED_OBJECTS = [
     'incident',

--- a/stix2validator/musts.py
+++ b/stix2validator/musts.py
@@ -2,6 +2,7 @@
 """
 
 import re
+from stix2patterns.validator import run_validator as pattern_validator
 from . import enums
 from .util import cyber_observable_check, has_cyber_observable_data
 from .errors import JSONError
@@ -273,6 +274,20 @@ def types_strict(instance):
                                 % (key, obj['type']), instance['id'])
 
 
+def patterns(instance):
+    """Ensure that the syntax of the pattern of an indicator is valid.
+    """
+    if instance['type'] != 'indicator' or 'pattern' not in instance:
+        return
+
+    pattern = instance['pattern']
+    errors = pattern_validator(pattern)
+
+    for e in errors:
+        yield JSONError("Pattern failed to validate: %s."
+                        % e, instance['id'])
+
+
 def list_musts(options):
     """Construct the list of 'MUST' validators to be run by the validator.
     """
@@ -284,7 +299,8 @@ def list_musts(options):
         observable_object_references,
         artifact_mime_type,
         character_set,
-        software_language
+        software_language,
+        patterns
     ]
 
     # --strict-types

--- a/stix2validator/scripts/stix2_validator.py
+++ b/stix2validator/scripts/stix2_validator.py
@@ -152,7 +152,7 @@ def _get_arg_parser(is_script=True):
         "--recursive",
         dest="recursive",
         action="store_true",
-        default=False,
+        default=True,
         help="Recursively descend into input directories."
     )
     parser.add_argument(

--- a/stix2validator/shoulds.py
+++ b/stix2validator/shoulds.py
@@ -1073,7 +1073,7 @@ def list_shoulds(options):
                 elif 'custom-object-extension-prefix-lax' not in options.disabled:
                     validator_list.append(CHECKS['custom-object-extension-prefix-lax'])
                 if ('custom-observable-properties-prefix' not in options.disabled and
-                        'custom-observable-properties-prefix' not in options.disabled):
+                        'custom-observable-properties-prefix-lax' not in options.disabled):
                     validator_list.append(CHECKS['custom-observable-properties-prefix'])
                 elif 'custom-observable-properties-prefix' not in options.disabled:
                     validator_list.append(CHECKS['custom-observable-properties-prefix'])

--- a/stix2validator/test/__init__.py
+++ b/stix2validator/test/__init__.py
@@ -2,8 +2,7 @@ import unittest
 import os
 from .. import validate_string, ValidationOptions, print_results
 
-# SCHEMA_DIR = os.path.abspath(os.path.dirname(__file__) + "../../schemas")
-SCHEMA_DIR = "/home/lu/Projects/cti-stix2-json-schemas/schemas"
+SCHEMA_DIR = os.path.abspath(os.path.dirname(__file__) + "../../schemas")
 
 
 class ValidatorTest(unittest.TestCase):

--- a/stix2validator/test/__init__.py
+++ b/stix2validator/test/__init__.py
@@ -1,9 +1,9 @@
 import unittest
 import os
-from .. import validate_string
-from ..util import ValidationOptions
+from .. import validate_string, ValidationOptions, print_results
 
-SCHEMA_DIR = os.path.abspath(os.path.dirname(__file__) + "../../schemas")
+# SCHEMA_DIR = os.path.abspath(os.path.dirname(__file__) + "../../schemas")
+SCHEMA_DIR = "/home/lu/Projects/cti-stix2-json-schemas/schemas"
 
 
 class ValidatorTest(unittest.TestCase):
@@ -33,6 +33,7 @@ class ValidatorTest(unittest.TestCase):
             options = ValidationOptions(schema_dir=SCHEMA_DIR, strict=True,
                                         **kwargs)
         results = validate_string(instance, options)
+        print_results(results)
         self.assertTrue(results.is_valid)
 
     def assertFalseWithOptions(self, instance, **kwargs):

--- a/stix2validator/test/attack_pattern_tests.py
+++ b/stix2validator/test/attack_pattern_tests.py
@@ -52,6 +52,8 @@ class AttackPatternTestCases(ValidatorTest):
         results = validate_string(attack_pattern_string, self.options)
         self.assertEqual(results.is_valid, False)
 
+        self.assertFalseWithOptions(attack_pattern_string, enabled='custom-property-prefix-lax')
+
     def test_invalid_property_prefix_lax(self):
         attack_pattern = copy.deepcopy(self.valid_attack_pattern)
         attack_pattern['x_something'] = "some value"
@@ -60,7 +62,7 @@ class AttackPatternTestCases(ValidatorTest):
         self.assertEqual(results.is_valid, False)
 
         self.assertTrueWithOptions(attack_pattern_string, enabled='custom-property-prefix-lax')
-
+        self.assertFalseWithOptions(attack_pattern_string, disabled='custom-property-prefix-lax')
         self.check_ignore(attack_pattern_string, 'custom-property-prefix')
 
     def test_valid_property_prefix(self):

--- a/stix2validator/test/custom_obj_tests.py
+++ b/stix2validator/test/custom_obj_tests.py
@@ -64,6 +64,9 @@ class CustomObjectTestCases(ValidatorTest):
         results = validate_string(custom_obj_string, self.options)
         self.assertEqual(results.is_valid, False)
 
+        self.assertFalseWithOptions(custom_obj_string, enabled='custom-object-prefix-lax')
+        self.assertFalseWithOptions(custom_obj_string, disabled='custom-object-prefix-lax')
+
     def test_invalid_type_name_lax(self):
         custom_obj = copy.deepcopy(self.valid_custom_object)
         custom_obj['type'] = "x-corporation"
@@ -73,7 +76,6 @@ class CustomObjectTestCases(ValidatorTest):
         self.assertEqual(results.is_valid, False)
 
         self.assertTrueWithOptions(custom_obj_string, enabled='custom-object-prefix-lax')
-
         self.check_ignore(custom_obj_string, 'custom-object-prefix')
 
     def test_valid_type_name(self):

--- a/stix2validator/test/indicator_tests.py
+++ b/stix2validator/test/indicator_tests.py
@@ -14,7 +14,7 @@ VALID_INDICATOR = """
     "labels": ["malicious-activity"],
     "name": "Poison Ivy Malware",
     "description": "This file is part of Poison Ivy",
-    "pattern": "file-object.hashes.md5 = '3773a88f65a5e780c8dff9cdc3a056f3'",
+    "pattern": "[file-object:hashes.md5 = '3773a88f65a5e780c8dff9cdc3a056f3']",
     "valid_from": "2016-04-06T20:03:48Z"
 }
 """
@@ -134,6 +134,11 @@ class IndicatorTestCases(ValidatorTest):
         self.assertEqual(results.is_valid, False)
 
         self.check_ignore(indicator, 'indicator-label')
+
+    def test_invalid_pattern(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator['pattern'] = "[file-object:hashes.md5 = '3773a88f65a5e780c8dff9cdc3a056f3'"
+        self.assertFalseWithOptions(json.dumps(indicator))
 
 
 if __name__ == "__main__":

--- a/stix2validator/test/marking_definition_tests.py
+++ b/stix2validator/test/marking_definition_tests.py
@@ -46,6 +46,12 @@ class MarkingDefinitionTestCases(ValidatorTest):
         marking_definition = json.dumps(marking_definition)
         self.assertFalseWithOptions(marking_definition)
 
+    def test_object_marking_ref_invalid_type(self):
+        marking_definition = copy.deepcopy(self.valid_marking_definition)
+        marking_definition['object_marking_refs'] = ["indicator--44098fce-860f-48ae-8e50-ebd3cc5e41da"]
+        marking_definition = json.dumps(marking_definition)
+        self.assertFalseWithOptions(marking_definition)
+
     def test_granular_marking_circular_ref(self):
         marking_definition = copy.deepcopy(self.valid_marking_definition)
         marking_definition['granular_markings'] = [{
@@ -60,6 +66,14 @@ class MarkingDefinitionTestCases(ValidatorTest):
         marking_definition['granular_markings'] = [{
             "marking_ref": "marking-definition--4478bf48-9af2-4afa-9fc5-7075f6af04af",
             "selectors": ["[0]"]
+        }]
+        self.assertFalseWithOptions(json.dumps(marking_definition))
+
+    def test_granular_marking_invalid_marking_ref_type(self):
+        marking_definition = copy.deepcopy(self.valid_marking_definition)
+        marking_definition['granular_markings'] = [{
+            "marking_ref": "indicator--3478bf48-9af2-4afa-9fc5-7075f6af04af",
+            "selectors": ["created"]
         }]
         self.assertFalseWithOptions(json.dumps(marking_definition))
 

--- a/stix2validator/test/observed_data_tests.py
+++ b/stix2validator/test/observed_data_tests.py
@@ -324,6 +324,18 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertTrueWithOptions(json.dumps(observed_data))
         self.assertFalseWithOptions(json.dumps(observed_data), strict_types=True)
 
+    def test_observable_object_types_prefix_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['0']['type'] = "foo"
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-object-prefix')
+        observed_data['objects']['0']['type'] = "x-foo"
+        self.assertFalseWithOptions(json.dumps(observed_data))
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-observable-object-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-object-prefix-lax')
+
     def test_observable_object_extensions(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
         observed_data['objects']['0']['extensions']['foobar'] = {
@@ -335,6 +347,24 @@ class ObservedDataTestCases(ValidatorTest):
         self.check_ignore(observed_data,
                           'custom-object-extension-prefix,custom-object-extension-prefix-lax')
 
+    def test_observable_object_extensions_prefix_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['0']['extensions']['foobar'] = {
+            "foo": "bar"
+        }
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-object-extension-prefix')
+
+        del observed_data['objects']['0']['extensions']['foobar']
+        observed_data['objects']['0']['extensions']['x-foobar'] = {
+            "foo": "bar"
+        }
+        self.assertFalseWithOptions(json.dumps(observed_data))
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-object-extension-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-object-extension-prefix-lax')
+
     def test_observable_object_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
         observed_data['objects']['0']['foo'] = "bar"
@@ -343,6 +373,21 @@ class ObservedDataTestCases(ValidatorTest):
 
         self.check_ignore(observed_data,
                           'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+        self.assertFalseWithOptions(observed_data,
+                                    disabled='custom-observable-properties-prefix-lax')
+
+    def test_observable_object_custom_properties_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['0']['foo'] = "bar"
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix')
+
+        del observed_data['objects']['0']['foo']
+        observed_data['objects']['0']['x_foo'] = "bar"
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-observable-properties-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix-lax')
 
     def test_observable_object_extension_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -352,6 +397,19 @@ class ObservedDataTestCases(ValidatorTest):
 
         self.check_ignore(observed_data,
                           'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+
+    def test_observable_object_extension_custom_properties_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['0']['extensions']['archive-ext']['foo'] = "bar"
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix')
+
+        del observed_data['objects']['0']['extensions']['archive-ext']['foo']
+        observed_data['objects']['0']['extensions']['archive-ext']['x_foo'] = "bar"
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-observable-properties-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix-lax')
 
     def test_observable_object_embedded_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -366,6 +424,24 @@ class ObservedDataTestCases(ValidatorTest):
 
         self.check_ignore(observed_data,
                           'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+
+    def test_observable_object_embedded_custom_properties_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['2'] = {
+            "type": "x509-certificate",
+            "x509_v3_extensions": {
+              "foo": "bar"
+            }
+        }
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix')
+
+        del observed_data['objects']['2']['x509_v3_extensions']['foo']
+        observed_data['objects']['2']['x509_v3_extensions']['x_foo'] = "bar"
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-observable-properties-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix-lax')
 
     def test_observable_object_embedded_dict_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -387,6 +463,30 @@ class ObservedDataTestCases(ValidatorTest):
         self.check_ignore(observed_data,
                           'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
 
+    def test_observable_object_embedded_dict_custom_properties_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['2'] = {
+            "type": "windows-registry-key",
+            "key": "hkey_local_machine\\system\\bar\\foo",
+            "values": [
+                {
+                    "name": "Foo",
+                    "data": "qwerty",
+                    "data_type": "REG_SZ",
+                    "foo": "buzz"
+                }
+            ]
+        }
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix')
+
+        del observed_data['objects']['2']['values'][0]['foo']
+        observed_data['objects']['2']['values'][0]['x_foo'] = "bar"
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-observable-properties-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix-lax')
+
     def test_observable_object_extension_embedded_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
         observed_data['objects']['0']['extensions']['ntfs-ext'] = {
@@ -403,6 +503,27 @@ class ObservedDataTestCases(ValidatorTest):
 
         self.check_ignore(observed_data,
                           'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+
+    def test_observable_object_extension_embedded_custom_properties_lax(self):
+        observed_data = copy.deepcopy(self.valid_observed_data)
+        observed_data['objects']['0']['extensions']['ntfs-ext'] = {
+            "alternate_data_streams": [
+                  {
+                      "name": "second.stream",
+                      "size": 25536,
+                      "foo": "bar"
+                  }
+              ]
+        }
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix')
+
+        del observed_data['objects']['0']['extensions']['ntfs-ext']['alternate_data_streams'][0]['foo']
+        observed_data['objects']['0']['extensions']['ntfs-ext']['alternate_data_streams'][0]['x_foo'] = "bar"
+        self.check_ignore(json.dumps(observed_data),
+                          'custom-observable-properties-prefix')
+        self.assertFalseWithOptions(json.dumps(observed_data),
+                                    disabled='custom-observable-properties-prefix-lax')
 
     def test_observable_object_property_reference(self):
         observed_data = copy.deepcopy(self.valid_observed_data)

--- a/stix2validator/test/relationship_tests.py
+++ b/stix2validator/test/relationship_tests.py
@@ -60,7 +60,7 @@ class RelationshipTestCases(ValidatorTest):
         results = validate_string(relationship, self.options)
         self.assertEqual(results.is_valid, False)
 
-    def test_relationship_types_invalid(self):
+    def test_relationship_types_invalid_type(self):
         relationship = copy.deepcopy(self.valid_relationship)
         relationship['source_ref'] = "malware--31b940d4-6f7f-459a-80ea-9c1f17b5891b"
         relationship['target_ref'] = "campaign--9c1f891b-459a-6f7f-80ea-31b940d417b5"
@@ -70,6 +70,16 @@ class RelationshipTestCases(ValidatorTest):
         self.assertEqual(results.is_valid, False)
 
         self.check_ignore(relationship, 'relationship-types')
+
+    def test_relationship_types_invalid_source(self):
+        relationship = copy.deepcopy(self.valid_relationship)
+        relationship['source_ref'] = "identity--b5437038-eb96-4652-88bc-5f94993b7326"
+        self.assertFalseWithOptions(json.dumps(relationship))
+
+    def test_relationship_types_invalid_target(self):
+        relationship = copy.deepcopy(self.valid_relationship)
+        relationship['target_ref'] = "report--af0976b2-e8f3-4646-8026-1cf4d0ce4d8a"
+        self.assertFalseWithOptions(json.dumps(relationship))
 
     def test_relationship_types_valid(self):
         relationship = copy.deepcopy(self.valid_relationship)
@@ -88,6 +98,11 @@ class RelationshipTestCases(ValidatorTest):
         relationship = json.dumps(relationship)
         results = validate_string(relationship, self.options)
         self.assertTrue(results.is_valid)
+
+    def test_missing_required(self):
+        relationship = copy.deepcopy(self.valid_relationship)
+        del relationship['relationship_type']
+        self.assertFalseWithOptions(json.dumps(relationship))
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,pycodestyle
+envlist = py27,py33,py34,py35,pycodestyle
 
 [testenv]
 deps = pytest
@@ -22,7 +22,6 @@ addopts = --ignore local/
 
 [travis]
 python =
-  2.6: py26
   2.7: py27, pycodestyle
   3.3: py33
   3.4: py34

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pycodestyle
+envlist = py27,py33,py34,py35,py36,pycodestyle
 
 [testenv]
 deps = pytest
@@ -26,3 +26,4 @@ python =
   3.3: py33
   3.4: py34
   3.5: py35
+  3.6: py36


### PR DESCRIPTION
- expanded tests
  - and added Python 3.6 to CI
- integrated the pattern validator
- bug fixes
  - threat-actor.goals was incorrectly defined as an open vocabulary
  - added some reserved properties that were left out
- the validator will search input directories recursively by default now

Note: Python 2.6 was removed from Tox when the pattern validator was integrated because the Python ANTLR library does not support it.