### PR TITLE
Validate custom object types and properties in patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,16 +97,13 @@ Some checks access Internet resources to determine valid values for certain prop
 +--------+-----------------------------+----------------------------------------+
 |   1    | format-checks               | all 1xx checks are run                 |
 +--------+-----------------------------+----------------------------------------+
-|  101   | custom-object-prefix        | custom object type names follow the    |
-|        |                             | correct format                         |
-+--------+-----------------------------+----------------------------------------+
-|  102   | custom-object-prefix-lax    | same as 101 but more lenient; no       |
-|        |                             | source identifier needed in prefix     |
-+--------+-----------------------------+----------------------------------------+
-|  103   | custom-property-prefix      | custom object property names follow    |
+|  101   | custom-prefix               | names of custom object types,          |
+|        |                             | properties, observable objects,        |
+|        |                             | observable object properties, and      |
+|        |                             | observable object extensions follow    |
 |        |                             | the correct format                     |
 +--------+-----------------------------+----------------------------------------+
-|  104   | custom-property-prefix-lax  | same as 103 but more lenient; no       |
+|  102   | custom-prefix-lax           | same as 101 but more lenient; no       |
 |        |                             | source identifier needed in prefix     |
 +--------+-----------------------------+----------------------------------------+
 |  111   | open-vocab-format           | values of open vocabularies follow the |
@@ -120,24 +117,6 @@ Some checks access Internet resources to determine valid values for certain prop
 +--------+-----------------------------+----------------------------------------+
 |  142   | observable-dictionary-keys  | dictionaries in cyber observable       |
 |        |                             | objects follow the correct format      |
-+--------+-----------------------------+----------------------------------------+
-|  143   | custom-observable-object-\  | custom observable object names follow  |
-|        | prefix                      | the correct format                     |
-+--------+-----------------------------+----------------------------------------+
-|  144   | custom-observable-object-\  | same as 144 but more lenient; no       |
-|        | prefix-lax                  | source identifier needed in prefix     |
-+--------+-----------------------------+----------------------------------------+
-|  145   | custom-object-extension-\   | custom observable object extension     |
-|        | prefix                      | names follow the correct format        |
-+--------+-----------------------------+----------------------------------------+
-|  146   | custom-object-extension-\   | same as 145 but more lenient; no       |
-|        | prefix-lax                  | source identifier needed in prefix     |
-+--------+-----------------------------+----------------------------------------+
-|  147   | custom-observable-\         | observable object custom property      |
-|        | properties-prefix           | names follow the correct format        |
-+--------+-----------------------------+----------------------------------------+
-|  148   | custom-observable-\         | same as 148 but more lenient; no       |
-|        | properties-prefix-lax       | source identifier needed in prefix     |
 +--------+-----------------------------+----------------------------------------+
 |  149   | windows-process-priority-\  | windows-process-ext's 'priority'       |
 |        | format                      | follows the correct format             |

--- a/stix2validator/enums.py
+++ b/stix2validator/enums.py
@@ -843,7 +843,7 @@ OBSERVABLE_EXTENSION_PROPERTIES = {
     ]
 }
 # Mappings of properties of embedded cyber observable types
-OBSERVABLE_EMBEDED_PROPERTIES = {
+OBSERVABLE_EMBEDDED_PROPERTIES = {
     'email-message': {
         'body_multipart': [
             'body',
@@ -880,7 +880,7 @@ OBSERVABLE_EMBEDED_PROPERTIES = {
         ]
     }
 }
-OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES = {
+OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES = {
     'ntfs-ext': {
         'alternate_data_streams': [
             'name',

--- a/stix2validator/errors.py
+++ b/stix2validator/errors.py
@@ -18,6 +18,14 @@ class JSONError(schema_exceptions.ValidationError):
         super(JSONError, self).__init__(msg, path=deque([instance_id]))
 
 
+class PatternError(JSONError):
+    """Represent a problem with a STIX Pattern.
+    """
+    def __init__(self, msg=None, instance_id=None, check_code=None):
+        msg = 'Pattern failed to validate: %s.' % msg
+        super(PatternError, self).__init__(msg, instance_id, check_code)
+
+
 class NoJSONFileFoundError(OSError):
     """Represent a problem finding the input JSON file(s).
 

--- a/stix2validator/musts.py
+++ b/stix2validator/musts.py
@@ -338,8 +338,10 @@ def patterns(instance):
     pattern = instance['pattern']
     errors = pattern_validator(pattern)
 
-    for e in errors:
-        yield PatternError(str(e), instance['id'])
+    if errors:
+        for e in errors:
+            yield PatternError(str(e), instance['id'])
+        return
 
     p = Pattern(pattern)
     inspection = p.inspect().comparisons
@@ -347,14 +349,13 @@ def patterns(instance):
         if objtype not in enums.OBSERVABLE_TYPES:
             yield PatternError("'%s' is not a valid observable type."
                                % objtype, instance['id'])
-        expression_list = inpection[objtype]
+        expression_list = inspection[objtype]
         for exp in expression_list:
             path = exp[0]
-            prop = path.split('.',1)[0]
+            prop = path.split('.', 1)[0]
             if prop not in enums.OBSERVABLE_PROPERTIES[objtype]:
                 yield PatternError("'%s' is not a valid property for '%s' objects."
                                    % (prop, objtype), instance['id'])
-
 
 
 def list_musts(options):

--- a/stix2validator/scripts/stix2_validator.py
+++ b/stix2validator/scripts/stix2_validator.py
@@ -21,13 +21,12 @@ the validator performs, along with the code to use with the --enable or
 | Code | Name                        | Ensures...                             |
 +------+-----------------------------+----------------------------------------+
 |  1   | format-checks               | all 1xx checks are run                 |
-| 101  | custom-object-prefix        | custom object type names follow the    |
-|      |                             | correct format                         |
-| 102  | custom-object-prefix-lax    | same as 101 but more lenient; no       |
-|      |                             | source identifier needed in prefix     |
-| 103  | custom-property-prefix      | custom object property names follow    |
+| 101  | custom-prefix               | names of custom object types,          |
+|      |                             | properties, observable objects,        |
+|      |                             | observable object properties, and      |
+|      |                             | observable object extensions follow    |
 |      |                             | the correct format                     |
-| 104  | custom-property-prefix-lax  | same as 103 but more lenient; no       |
+| 102  | custom-prefix-lax           | same as 101 but more lenient; no       |
 |      |                             | source identifier needed in prefix     |
 | 111  | open-vocab-format           | values of open vocabularies follow the |
 |      |                             | correct format                         |
@@ -37,18 +36,6 @@ the validator performs, along with the code to use with the --enable or
 |      |                             | correct format                         |
 | 142  | observable-dictionary-keys  | dictionaries in cyber observable       |
 |      |                             | objects follow the correct format      |
-| 143  | custom-observable-object-   | custom observable object names follow  |
-|      |     prefix                  | the correct format                     |
-| 144  | custom-observable-object-   | same as 144 but more lenient; no       |
-|      |     prefix-lax              | source identifier needed in prefix     |
-| 145  | custom-object-extension-    | custom observable object extension     |
-|      |     prefix                  | names follow the correct format        |
-| 146  | custom-object-extension-    | same as 145 but more lenient; no       |
-|      |     prefix-lax              | source identifier needed in prefix     |
-| 147  | custom-observable-          | observable object custom property      |
-|      |     properties-prefix       | names follow the correct format        |
-| 148  | custom-observable-          | same as 148 but more lenient; no       |
-|      |     properties-prefix-lax   | source identifier needed in prefix     |
 | 149  | windows-process-priority-   | windows-process-ext's 'priority'       |
 |      |     format                  | follows the correct format             |
 | 150  | hash-length                 | keys in 'hashes'-type properties are   |

--- a/stix2validator/shoulds.py
+++ b/stix2validator/shoulds.py
@@ -22,6 +22,37 @@ from .errors import JSONError
 from .output import info
 
 
+def custom_prefix_strict(instance):
+    """Ensure custom content follows strict naming style conventions.
+    """
+    for error in custom_object_prefix_strict(instance):
+        yield error
+    for error in custom_property_prefix_strict(instance):
+        yield error
+    for error in custom_observable_object_prefix_strict(instance):
+        yield error
+    for error in custom_object_extension_prefix_strict(instance):
+        yield error
+    for error in custom_observable_properties_prefix_strict(instance):
+        yield error
+
+
+def custom_prefix_lax(instance):
+    """Ensure custom content follows lenient naming style conventions
+    for forward-compatibility.
+    """
+    for error in custom_object_prefix_lax(instance):
+        yield error
+    for error in custom_property_prefix_lax(instance):
+        yield error
+    for error in custom_observable_object_prefix_lax(instance):
+        yield error
+    for error in custom_object_extension_prefix_lax(instance):
+        yield error
+    for error in custom_observable_properties_prefix_lax(instance):
+        yield error
+
+
 def custom_object_prefix_strict(instance):
     """Ensure custom objects follow strict naming style conventions.
     """
@@ -1047,20 +1078,12 @@ CHECKS = {
         windows_process_priority_format,
         hash_length,
     ],
-    'custom-object-prefix': custom_object_prefix_strict,
-    'custom-object-prefix-lax': custom_object_prefix_lax,
-    'custom-property-prefix': custom_property_prefix_strict,
-    'custom-property-prefix-lax': custom_property_prefix_lax,
+    'custom-prefix': custom_prefix_strict,
+    'custom-prefix-lax': custom_prefix_lax,
     'open-vocab-format': open_vocab_values,
     'kill-chain-names': kill_chain_phase_names,
     'observable-object-keys': observable_object_keys,
     'observable-dictionary-keys': observable_dictionary_keys,
-    'custom-observable-object-prefix': custom_observable_object_prefix_strict,
-    'custom-observable-object-prefix-lax': custom_observable_object_prefix_lax,
-    'custom-object-extension-prefix': custom_object_extension_prefix_strict,
-    'custom-object-extension-prefix-lax': custom_object_extension_prefix_lax,
-    'custom-observable-properties-prefix': custom_observable_properties_prefix_strict,
-    'custom-observable-properties-prefix-lax': custom_observable_properties_prefix_lax,
     'windows-process-priority-format': windows_process_priority_format,
     'hash-length': hash_length,
     'approved-values': [
@@ -1156,20 +1179,13 @@ def list_shoulds(options):
     if options.disabled:
         if 'all' not in options.disabled:
             if 'format-checks' not in options.disabled:
-                if ('custom-object-prefix' not in options.disabled and
-                        'custom-object-prefix-lax' not in options.disabled):
-                    validator_list.append(CHECKS['custom-object-prefix'])
-                elif 'custom-object-prefix' not in options.disabled:
-                    validator_list.append(CHECKS['custom-object-prefix'])
-                elif 'custom-object-prefix-lax' not in options.disabled:
-                    validator_list.append(CHECKS['custom-object-prefix-lax'])
-                if ('custom-property-prefix' not in options.disabled and
-                        'custom-property-prefix-lax' not in options.disabled):
-                    validator_list.append(CHECKS['custom-property-prefix'])
-                elif 'custom-property-prefix' not in options.disabled:
-                    validator_list.append(CHECKS['custom-property-prefix'])
-                elif 'custom-property-prefix-lax' not in options.disabled:
-                    validator_list.append(CHECKS['custom-property-prefix-lax'])
+                if ('custom-prefix' not in options.disabled and
+                        'custom-prefix-lax' not in options.disabled):
+                    validator_list.append(CHECKS['custom-prefix'])
+                elif 'custom-prefix' not in options.disabled:
+                    validator_list.append(CHECKS['custom-prefix'])
+                elif 'custom-prefix-lax' not in options.disabled:
+                    validator_list.append(CHECKS['custom-prefix-lax'])
                 if 'open-vocab-format' not in options.disabled:
                     validator_list.append(CHECKS['open-vocab-format'])
                 if 'kill-chain-names' not in options.disabled:
@@ -1178,27 +1194,6 @@ def list_shoulds(options):
                     validator_list.append(CHECKS['observable-object-keys'])
                 if 'observable-dictionary-keys' not in options.disabled:
                     validator_list.append(CHECKS['observable-dictionary-keys'])
-                if ('custom-observable-object-prefix' not in options.disabled and
-                        'custom-observable-object-prefix-lax' not in options.disabled):
-                    validator_list.append(CHECKS['custom-observable-object-prefix'])
-                elif 'custom-observable-object-prefix' not in options.disabled:
-                    validator_list.append(CHECKS['custom-observable-object-prefix'])
-                elif 'custom-observable-object-prefix-lax' not in options.disabled:
-                    validator_list.append(CHECKS['custom-observable-object-prefix-lax'])
-                if ('custom-object-extension-prefix' not in options.disabled and
-                        'custom-object-extension-prefix-lax' not in options.disabled):
-                    validator_list.append(CHECKS['custom-object-extension-prefix'])
-                elif 'custom-object-extension-prefix' not in options.disabled:
-                    validator_list.append(CHECKS['custom-object-extension-prefix'])
-                elif 'custom-object-extension-prefix-lax' not in options.disabled:
-                    validator_list.append(CHECKS['custom-object-extension-prefix-lax'])
-                if ('custom-observable-properties-prefix' not in options.disabled and
-                        'custom-observable-properties-prefix-lax' not in options.disabled):
-                    validator_list.append(CHECKS['custom-observable-properties-prefix'])
-                elif 'custom-observable-properties-prefix' not in options.disabled:
-                    validator_list.append(CHECKS['custom-observable-properties-prefix'])
-                elif 'custom-observable-properties-prefix-lax' not in options.disabled:
-                    validator_list.append(CHECKS['custom-observable-properties-prefix-lax'])
                 if 'windows-process-priority-format' not in options.disabled:
                     validator_list.append(CHECKS['windows-process-priority-format'])
                 if 'hash-length' not in options.disabled:

--- a/stix2validator/shoulds.py
+++ b/stix2validator/shoulds.py
@@ -1179,10 +1179,7 @@ def list_shoulds(options):
     if options.disabled:
         if 'all' not in options.disabled:
             if 'format-checks' not in options.disabled:
-                if ('custom-prefix' not in options.disabled and
-                        'custom-prefix-lax' not in options.disabled):
-                    validator_list.append(CHECKS['custom-prefix'])
-                elif 'custom-prefix' not in options.disabled:
+                if 'custom-prefix' not in options.disabled:
                     validator_list.append(CHECKS['custom-prefix'])
                 elif 'custom-prefix-lax' not in options.disabled:
                     validator_list.append(CHECKS['custom-prefix-lax'])

--- a/stix2validator/shoulds.py
+++ b/stix2validator/shoulds.py
@@ -15,25 +15,24 @@ To add a new check:
 
 import re
 from collections import Iterable
+from itertools import chain
 from six import string_types
 from . import enums
 from .util import cyber_observable_check
 from .errors import JSONError
+from .musts import (CUSTOM_TYPE_PREFIX_RE, CUSTOM_TYPE_LAX_PREFIX_RE,
+                    CUSTOM_PROPERTY_PREFIX_RE, CUSTOM_PROPERTY_LAX_PREFIX_RE)
 from .output import info
 
 
 def custom_prefix_strict(instance):
     """Ensure custom content follows strict naming style conventions.
     """
-    for error in custom_object_prefix_strict(instance):
-        yield error
-    for error in custom_property_prefix_strict(instance):
-        yield error
-    for error in custom_observable_object_prefix_strict(instance):
-        yield error
-    for error in custom_object_extension_prefix_strict(instance):
-        yield error
-    for error in custom_observable_properties_prefix_strict(instance):
+    for error in chain(custom_object_prefix_strict(instance),
+                       custom_property_prefix_strict(instance),
+                       custom_observable_object_prefix_strict(instance),
+                       custom_object_extension_prefix_strict(instance),
+                       custom_observable_properties_prefix_strict(instance)):
         yield error
 
 
@@ -41,15 +40,11 @@ def custom_prefix_lax(instance):
     """Ensure custom content follows lenient naming style conventions
     for forward-compatibility.
     """
-    for error in custom_object_prefix_lax(instance):
-        yield error
-    for error in custom_property_prefix_lax(instance):
-        yield error
-    for error in custom_observable_object_prefix_lax(instance):
-        yield error
-    for error in custom_object_extension_prefix_lax(instance):
-        yield error
-    for error in custom_observable_properties_prefix_lax(instance):
+    for error in chain(custom_object_prefix_lax(instance),
+                       custom_property_prefix_lax(instance),
+                       custom_observable_object_prefix_lax(instance),
+                       custom_object_extension_prefix_lax(instance),
+                       custom_observable_properties_prefix_lax(instance)):
         yield error
 
 
@@ -58,10 +53,10 @@ def custom_object_prefix_strict(instance):
     """
     if (instance['type'] not in enums.TYPES and
             instance['type'] not in enums.RESERVED_OBJECTS and
-            not re.match("^x\-.+\-.+$", instance['type'])):
+            not CUSTOM_TYPE_PREFIX_RE.match(instance['type'])):
         yield JSONError("Custom object type '%s' should start with 'x-' "
                         "followed by a source unique identifier (like a "
-                        "domain name with dots replaced by dashes), a dash "
+                        "domain name with dots replaced by hyphens), a hyphen "
                         "and then the name." % instance['type'],
                         instance['id'], 'custom-object-prefix')
 
@@ -72,7 +67,7 @@ def custom_object_prefix_lax(instance):
     """
     if (instance['type'] not in enums.TYPES and
             instance['type'] not in enums.RESERVED_OBJECTS and
-            not re.match("^x\-.+$", instance['type'])):
+            not CUSTOM_TYPE_LAX_PREFIX_RE.match(instance['type'])):
         yield JSONError("Custom object type '%s' should start with 'x-' in "
                         "order to be compatible with future versions of the "
                         "STIX 2 specification." % instance['type'],
@@ -88,13 +83,13 @@ def custom_property_prefix_strict(instance):
         if (instance['type'] in enums.PROPERTIES and
                 prop_name not in enums.PROPERTIES[instance['type']] and
                 prop_name not in enums.RESERVED_PROPERTIES and
-                not re.match("^x_.+_.+$", prop_name)):
+                not CUSTOM_PROPERTY_PREFIX_RE.match(prop_name)):
 
             yield JSONError("Custom property '%s' should have a type that "
                             "starts with 'x_' followed by a source unique "
                             "identifier (like a domain name with dots "
-                            "replaced by dashes), a dash and then the name." %
-                            prop_name, instance['id'],
+                            "replaced by hyphen), a hyphen and then the name."
+                            % prop_name, instance['id'],
                             'custom-property-prefix')
 
 
@@ -108,7 +103,7 @@ def custom_property_prefix_lax(instance):
         if (instance['type'] in enums.PROPERTIES and
                 prop_name not in enums.PROPERTIES[instance['type']] and
                 prop_name not in enums.RESERVED_PROPERTIES and
-                not re.match("^x_.+$", prop_name)):
+                not CUSTOM_PROPERTY_LAX_PREFIX_RE.match(prop_name)):
 
             yield JSONError("Custom property '%s' should have a type that "
                             "starts with 'x_' in order to be compatible with "
@@ -119,7 +114,7 @@ def custom_property_prefix_lax(instance):
 
 def open_vocab_values(instance):
     """Ensure that the values of all properties which use open vocabularies are
-    in lowercase and use dashes instead of spaces or underscores as word
+    in lowercase and use hyphens instead of spaces or underscores as word
     separators.
     """
     if instance['type'] not in enums.VOCAB_PROPERTIES:
@@ -137,7 +132,7 @@ def open_vocab_values(instance):
             for v in values:
                 if not v.islower() or '_' in v or ' ' in v:
                     yield JSONError("Open vocabulary value '%s' should be all"
-                                    " lowercase and use dashes instead of"
+                                    " lowercase and use hyphens instead of"
                                     " spaces or underscores as word"
                                     " separators." % v, instance['id'],
                                     'open-vocab-format')
@@ -157,14 +152,14 @@ def kill_chain_phase_names(instance):
             chain_name = phase['kill_chain_name']
             if not chain_name.islower() or '_' in chain_name or ' ' in chain_name:
                 yield JSONError("kill_chain_name '%s' should be all lowercase"
-                                " and use dashes instead of spaces or "
+                                " and use hyphens instead of spaces or "
                                 "underscores as word separators." % chain_name,
                                 instance['id'], 'kill-chain-names')
 
             phase_name = phase['phase_name']
             if not phase_name.islower() or '_' in phase_name or ' ' in phase_name:
                 yield JSONError("phase_name '%s' should be all lowercase and "
-                                "use dashes instead of spaces or underscores "
+                                "use hyphens instead of spaces or underscores "
                                 "as word separators." % phase_name,
                                 instance['id'], 'kill-chain-names')
 
@@ -309,7 +304,8 @@ def valid_hash_value(hashname):
     """Return true if given value is a valid, recommended hash name according
     to the STIX 2 specification.
     """
-    if hashname in enums.HASH_ALGO_OV or re.match("^x_", hashname):
+    custom_hash_prefix_re = re.compile("^x_")
+    if hashname in enums.HASH_ALGO_OV or custom_hash_prefix_re.match(hashname):
         return True
     else:
         return False
@@ -476,8 +472,9 @@ def vocab_account_type(instance):
 def observable_object_keys(instance):
     """Ensure observable-objects keys are non-negative integers.
     """
+    digits_re = re.compile("^\d+$")
     for key in instance['objects']:
-        if not re.match("^\d+$", key):
+        if not digits_re.match(key):
             yield JSONError("'%s' is not a good key value. Observable Objects "
                             "should use non-negative integers for their keys."
                             % key, instance['id'], 'observable-object-keys')
@@ -487,8 +484,9 @@ def test_dict_keys(item, inst_id):
     """Recursively generate errors for incorrectly formatted cyber observable
     dictionary keys.
     """
+    not_caps_re = re.compile("^[^A-Z]+$")
     for k, v in item.items():
-        if not re.match("^[^A-Z]+$", k):
+        if not not_caps_re.match(k):
             yield JSONError("As a dictionary key for cyber observable "
                             "objects, '%s' should be lowercase." % k,
                             inst_id, 'observable-dictionary-keys')
@@ -519,11 +517,11 @@ def custom_observable_object_prefix_strict(instance):
     for key, obj in instance['objects'].items():
         if ('type' in obj and obj['type'] not in enums.OBSERVABLE_TYPES and
                 obj['type'] not in enums.OBSERVABLE_RESERVED_OBJECTS and
-                not re.match("^x\-.+\-.+$", obj['type'])):
+                not CUSTOM_TYPE_PREFIX_RE.match(obj['type'])):
             yield JSONError("Custom Observable Object type '%s' should start "
                             "with 'x-' followed by a source unique identifier "
                             "(like a domain name with dots replaced by "
-                            "dashes), a dash and then the name."
+                            "hyphens), a hyphen and then the name."
                             % obj['type'], instance['id'],
                             'custom-observable-object-prefix')
 
@@ -535,7 +533,7 @@ def custom_observable_object_prefix_lax(instance):
     for key, obj in instance['objects'].items():
         if ('type' in obj and obj['type'] not in enums.OBSERVABLE_TYPES and
                 obj['type'] not in enums.OBSERVABLE_RESERVED_OBJECTS and
-                not re.match("^x\-.+$", obj['type'])):
+                not CUSTOM_TYPE_LAX_PREFIX_RE.match(obj['type'])):
             yield JSONError("Custom Observable Object type '%s' should start "
                             "with 'x-'."
                             % obj['type'], instance['id'],
@@ -553,11 +551,11 @@ def custom_object_extension_prefix_strict(instance):
             continue
         for ext_key in obj['extensions']:
             if (ext_key not in enums.OBSERVABLE_EXTENSIONS[obj['type']] and
-                    not re.match("^x\-.+\-.+$", ext_key)):
+                    not CUSTOM_TYPE_PREFIX_RE.match(ext_key)):
                 yield JSONError("Custom Cyber Observable Object extension type"
                                 " '%s' should start with 'x-' followed by a source "
                                 "unique identifier (like a domain name with dots "
-                                "replaced by dashes), a dash and then the name."
+                                "replaced by hyphens), a hyphen and then the name."
                                 % ext_key, instance['id'],
                                 'custom-object-extension-prefix')
 
@@ -573,7 +571,7 @@ def custom_object_extension_prefix_lax(instance):
             continue
         for ext_key in obj['extensions']:
             if (ext_key not in enums.OBSERVABLE_EXTENSIONS[obj['type']] and
-                    not re.match("^x\-.+$", ext_key)):
+                    not CUSTOM_TYPE_LAX_PREFIX_RE.match(ext_key)):
                 yield JSONError("Custom Cyber Observable Object extension type"
                                 " '%s' should start with 'x-'."
                                 % ext_key, instance['id'],
@@ -594,11 +592,11 @@ def custom_observable_properties_prefix_strict(instance):
             # Check objects' properties
             if (type_ in enums.OBSERVABLE_PROPERTIES and
                 prop not in enums.OBSERVABLE_PROPERTIES[type_] and
-                    not re.match("^x_.+\_.+$", prop)):
+                    not CUSTOM_PROPERTY_PREFIX_RE.match(prop)):
                 yield JSONError("Cyber Observable Object custom property '%s' "
                                 "should start with 'x_' followed by a source "
                                 "unique identifier (like a domain name with "
-                                "dots replaced by dashes), a dash and then the"
+                                "dots replaced by hyphens), a hyphen and then the"
                                 " name."
                                 % prop, instance['id'],
                                 'custom-observable-properties-prefix')
@@ -609,24 +607,24 @@ def custom_observable_properties_prefix_strict(instance):
                     if isinstance(embed_prop, dict):
                         for embedded in embed_prop:
                             if (embedded not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
-                                    not re.match("^x_.+\_.+$", embedded)):
+                                    not CUSTOM_PROPERTY_PREFIX_RE.match(embedded)):
                                 yield JSONError("Cyber Observable Object custom "
                                                 "property '%s' in the %s property of "
                                                 "%s object should start with 'x_' "
                                                 "followed by a source unique "
                                                 "identifier (like a domain name with "
-                                                "dots replaced by dashes), a dash and "
+                                                "dots replaced by hyphens), a hyphen and "
                                                 "then the name."
                                                 % (embedded, prop, type_), instance['id'],
                                                 'custom-observable-properties-prefix')
                     elif (embed_prop not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
-                            not re.match("^x_.+\_.+$", embed_prop)):
+                            not CUSTOM_PROPERTY_PREFIX_RE.match(embed_prop)):
                         yield JSONError("Cyber Observable Object custom "
                                         "property '%s' in the %s property of "
                                         "%s object should start with 'x_' "
                                         "followed by a source unique "
                                         "identifier (like a domain name with "
-                                        "dots replaced by dashes), a dash and "
+                                        "dots replaced by hyphens), a hyphen and "
                                         "then the name."
                                         % (embed_prop, prop, type_), instance['id'],
                                         'custom-observable-properties-prefix')
@@ -638,13 +636,13 @@ def custom_observable_properties_prefix_strict(instance):
                 if ext_key in enums.OBSERVABLE_EXTENSIONS[type_]:
                     for ext_prop in obj['extensions'][ext_key]:
                         if (ext_prop not in enums.OBSERVABLE_EXTENSION_PROPERTIES[ext_key] and
-                                not re.match("^x_.+\_.+$", ext_prop)):
+                                not CUSTOM_PROPERTY_PREFIX_RE.match(ext_prop)):
                             yield JSONError("Cyber Observable Object custom "
                                             "property '%s' in the %s extension "
                                             "should start with 'x_' followed by a "
                                             "source unique identifier (like a "
                                             "domain name with dots replaced by "
-                                            "dashes), a dash and then the name."
+                                            "hyphens), a hyphen and then the name."
                                             % (ext_prop, ext_key), instance['id'],
                                             'custom-observable-properties-prefix')
 
@@ -657,14 +655,14 @@ def custom_observable_properties_prefix_strict(instance):
                                     embed_prop = [embed_prop]
                                 for p in embed_prop:
                                     if (p not in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES[ext_key][ext_prop] and
-                                            not re.match("^x_.+\_.+$", p)):
+                                            not CUSTOM_PROPERTY_PREFIX_RE.match(p)):
                                         yield JSONError("Cyber Observable Object "
                                                         "custom property '%s' in the %s "
                                                         "property of the %s extension should "
                                                         "start with 'x_' followed by a source "
                                                         "unique identifier (like a domain name"
-                                                        " with dots replaced by dashes), a "
-                                                        "dash and then the name."
+                                                        " with dots replaced by hyphens), a "
+                                                        "hyphen and then the name."
                                                         % (p, ext_prop, ext_key), instance['id'],
                                                         'custom-observable-properties-prefix')
 
@@ -683,7 +681,7 @@ def custom_observable_properties_prefix_lax(instance):
             # Check objects' properties
             if (type_ in enums.OBSERVABLE_PROPERTIES and
                 prop not in enums.OBSERVABLE_PROPERTIES[type_] and
-                    not re.match("^x_.+$", prop)):
+                    not CUSTOM_PROPERTY_LAX_PREFIX_RE.match(prop)):
                 yield JSONError("Cyber Observable Object custom property '%s' "
                                 "should start with 'x_'."
                                 % prop, instance['id'],
@@ -695,14 +693,14 @@ def custom_observable_properties_prefix_lax(instance):
                     if isinstance(embed_prop, dict):
                         for embedded in embed_prop:
                             if (embedded not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
-                                    not re.match("^x_.+$", embedded)):
+                                    not CUSTOM_PROPERTY_LAX_PREFIX_RE.match(embedded)):
                                 yield JSONError("Cyber Observable Object custom "
                                                 "property '%s' in the %s property of "
                                                 "%s object should start with 'x_'."
                                                 % (embedded, prop, type_), instance['id'],
                                                 'custom-observable-properties-prefix')
                     elif (embed_prop not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
-                            not re.match("^x_.+$", embed_prop)):
+                            not CUSTOM_PROPERTY_LAX_PREFIX_RE.match(embed_prop)):
                         yield JSONError("Cyber Observable Object custom "
                                         "property '%s' in the %s property of "
                                         "%s object should start with 'x_'."
@@ -716,7 +714,7 @@ def custom_observable_properties_prefix_lax(instance):
                 if ext_key in enums.OBSERVABLE_EXTENSIONS[type_]:
                     for ext_prop in obj['extensions'][ext_key]:
                         if (ext_prop not in enums.OBSERVABLE_EXTENSION_PROPERTIES[ext_key] and
-                                not re.match("^x_.+$", ext_prop)):
+                                not CUSTOM_PROPERTY_LAX_PREFIX_RE.match(ext_prop)):
                             yield JSONError("Cyber Observable Object custom "
                                             "property '%s' in the %s extension "
                                             "should start with 'x_'."
@@ -732,7 +730,7 @@ def custom_observable_properties_prefix_lax(instance):
                                     embed_prop = [embed_prop]
                                 for p in embed_prop:
                                     if (p not in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES[ext_key][ext_prop] and
-                                            not re.match("^x_.+$", p)):
+                                            not CUSTOM_PROPERTY_LAX_PREFIX_RE.match(p)):
                                         yield JSONError("Cyber Observable Object "
                                                         "custom property '%s' in the %s "
                                                         "property of the %s extension should "
@@ -758,6 +756,8 @@ def mime_type(instance):
     """Ensure the 'mime_type' property of file objects comes from the Template
     column in the IANA media type registry.
     """
+    mime_pattern = re.compile('^(application|audio|font|image|message|model'
+                              '|multipart|text|video)/[a-zA-Z0-9.+_-]+')
     for key, obj in instance['objects'].items():
         if ('type' in obj and obj['type'] == 'file' and 'mime_type' in obj):
             if enums.media_types():
@@ -769,9 +769,7 @@ def mime_type(instance):
                                     'mime-type')
             else:
                 info("Can't reach IANA website; using regex for mime types.")
-                mime_pattern = '^(application|audio|font|image|message|model' \
-                               '|multipart|text|video)/[a-zA-Z0-9.+_-]+'
-                if not re.match(mime_pattern, obj['mime_type']):
+                if not mime_pattern.match(obj['mime_type']):
                     yield JSONError("The 'mime_type' property of object '%s' "
                                     "('%s') should be an IANA MIME Type of the"
                                     " form 'type/subtype'."
@@ -788,6 +786,7 @@ def protocols(instance):
     for key, obj in instance['objects'].items():
         if ('type' in obj and obj['type'] == 'network-traffic' and
                 'protocols' in obj):
+            prot_pattern = '^[a-zA-Z0-9-]{1,15}$'
             for prot in obj['protocols']:
                 if enums.protocols():
                     if prot not in enums.protocols():
@@ -799,8 +798,7 @@ def protocols(instance):
                                         'protocols')
                 else:
                     info("Can't reach IANA website; using regex for protocols.")
-                    prot_pattern = '^[a-zA-Z0-9-]{1,15}$'
-                    if not re.match(prot_pattern, prot):
+                    if not prot_pattern.match(prot):
                         yield JSONError("The 'protocols' property of object "
                                         "'%s' contains a value ('%s') not in "
                                         "IANA Service Name and Transport "
@@ -814,6 +812,7 @@ def ipfix(instance):
     """Ensure the 'protocols' property of network-traffic objects contains only
     values from the IANA IP Flow Information Export (IPFIX) Entities Registry.
     """
+    ipf_pattern = re.compile('^[a-z][a-zA-Z0-9]+')
     for key, obj in instance['objects'].items():
         if ('type' in obj and obj['type'] == 'network-traffic' and
                 'ipfix' in obj):
@@ -828,8 +827,7 @@ def ipfix(instance):
                                         'ipfix')
                 else:
                     info("Can't reach IANA website; using regex for ipfix.")
-                    ipf_pattern = '^[a-z][a-zA-Z0-9]+'
-                    if not re.match(ipf_pattern, ipf):
+                    if not ipf_pattern.match(ipf):
                         yield JSONError("The 'ipfix' property of object "
                                         "'%s' contains a key ('%s') not in "
                                         "IANA IP Flow Information Export "
@@ -910,13 +908,14 @@ def pdf_doc_info(instance):
 def windows_process_priority_format(instance):
     """Ensure the 'priority' property of windows-process-ext ends in '_CLASS'.
     """
+    class_suffix_re = re.compile('.+_CLASS$')
     for key, obj in instance['objects'].items():
         if 'type' in obj and obj['type'] == 'process':
             try:
                 priority = obj['extensions']['windows-process-ext']['priority']
             except KeyError:
                 continue
-            if not re.match('.+_CLASS$', priority):
+            if not class_suffix_re.match(priority):
                 yield JSONError("The 'priority' property of object '%s' should"
                                 " end in '_CLASS'." % key, instance['id'],
                                 'windows-process-priority-format')

--- a/stix2validator/shoulds.py
+++ b/stix2validator/shoulds.py
@@ -572,12 +572,12 @@ def custom_observable_properties_prefix_strict(instance):
                                 % prop, instance['id'],
                                 'custom-observable-properties-prefix')
             # Check properties of embedded cyber observable types
-            if (type_ in enums.OBSERVABLE_EMBEDED_PROPERTIES and
-                    prop in enums.OBSERVABLE_EMBEDED_PROPERTIES[type_]):
+            if (type_ in enums.OBSERVABLE_EMBEDDED_PROPERTIES and
+                    prop in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_]):
                 for embed_prop in obj[prop]:
                     if isinstance(embed_prop, dict):
                         for embedded in embed_prop:
-                            if (embedded not in enums.OBSERVABLE_EMBEDED_PROPERTIES[type_][prop] and
+                            if (embedded not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
                                     not re.match("^x_.+\_.+$", embedded)):
                                 yield JSONError("Cyber Observable Object custom "
                                                 "property '%s' in the %s property of "
@@ -588,7 +588,7 @@ def custom_observable_properties_prefix_strict(instance):
                                                 "then the name."
                                                 % (embedded, prop, type_), instance['id'],
                                                 'custom-observable-properties-prefix')
-                    elif (embed_prop not in enums.OBSERVABLE_EMBEDED_PROPERTIES[type_][prop] and
+                    elif (embed_prop not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
                             not re.match("^x_.+\_.+$", embed_prop)):
                         yield JSONError("Cyber Observable Object custom "
                                         "property '%s' in the %s property of "
@@ -619,13 +619,13 @@ def custom_observable_properties_prefix_strict(instance):
 
                 if ext_key in enums.OBSERVABLE_EXTENSIONS[type_]:
                     for ext_prop in obj['extensions'][ext_key]:
-                        if (ext_key in enums.OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES and
-                                ext_prop in enums.OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES[ext_key]):
+                        if (ext_key in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES and
+                                ext_prop in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES[ext_key]):
                             for embed_prop in obj['extensions'][ext_key][ext_prop]:
                                 if not (isinstance(embed_prop, Iterable) and not isinstance(embed_prop, string_types)):
                                     embed_prop = [embed_prop]
                                 for p in embed_prop:
-                                    if (p not in enums.OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES[ext_key][ext_prop] and
+                                    if (p not in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES[ext_key][ext_prop] and
                                             not re.match("^x_.+\_.+$", p)):
                                         yield JSONError("Cyber Observable Object "
                                                         "custom property '%s' in the %s "
@@ -658,19 +658,19 @@ def custom_observable_properties_prefix_lax(instance):
                                 % prop, instance['id'],
                                 'custom-observable-properties-prefix')
             # Check properties of embedded cyber observable types
-            if (type_ in enums.OBSERVABLE_EMBEDED_PROPERTIES and
-                    prop in enums.OBSERVABLE_EMBEDED_PROPERTIES[type_]):
+            if (type_ in enums.OBSERVABLE_EMBEDDED_PROPERTIES and
+                    prop in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_]):
                 for embed_prop in obj[prop]:
                     if isinstance(embed_prop, dict):
                         for embedded in embed_prop:
-                            if (embedded not in enums.OBSERVABLE_EMBEDED_PROPERTIES[type_][prop] and
+                            if (embedded not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
                                     not re.match("^x_.+$", embedded)):
                                 yield JSONError("Cyber Observable Object custom "
                                                 "property '%s' in the %s property of "
                                                 "%s object should start with 'x_'."
                                                 % (embedded, prop, type_), instance['id'],
                                                 'custom-observable-properties-prefix')
-                    elif (embed_prop not in enums.OBSERVABLE_EMBEDED_PROPERTIES[type_][prop] and
+                    elif (embed_prop not in enums.OBSERVABLE_EMBEDDED_PROPERTIES[type_][prop] and
                             not re.match("^x_.+$", embed_prop)):
                         yield JSONError("Cyber Observable Object custom "
                                         "property '%s' in the %s property of "
@@ -694,13 +694,13 @@ def custom_observable_properties_prefix_lax(instance):
 
                 if ext_key in enums.OBSERVABLE_EXTENSIONS[type_]:
                     for ext_prop in obj['extensions'][ext_key]:
-                        if (ext_key in enums.OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES and
-                                ext_prop in enums.OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES[ext_key]):
+                        if (ext_key in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES and
+                                ext_prop in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES[ext_key]):
                             for embed_prop in obj['extensions'][ext_key][ext_prop]:
                                 if not (isinstance(embed_prop, Iterable) and not isinstance(embed_prop, string_types)):
                                     embed_prop = [embed_prop]
                                 for p in embed_prop:
-                                    if (p not in enums.OBSERVABLE_EXTENSION_EMBEDED_PROPERTIES[ext_key][ext_prop] and
+                                    if (p not in enums.OBSERVABLE_EXTENSION_EMBEDDED_PROPERTIES[ext_key][ext_prop] and
                                             not re.match("^x_.+$", p)):
                                         yield JSONError("Cyber Observable Object "
                                                         "custom property '%s' in the %s "

--- a/stix2validator/test/attack_pattern_tests.py
+++ b/stix2validator/test/attack_pattern_tests.py
@@ -52,7 +52,7 @@ class AttackPatternTestCases(ValidatorTest):
         results = validate_string(attack_pattern_string, self.options)
         self.assertEqual(results.is_valid, False)
 
-        self.assertFalseWithOptions(attack_pattern_string, enabled='custom-property-prefix-lax')
+        self.assertFalseWithOptions(attack_pattern_string, enabled='custom-prefix-lax')
 
     def test_invalid_property_prefix_lax(self):
         attack_pattern = copy.deepcopy(self.valid_attack_pattern)
@@ -61,9 +61,9 @@ class AttackPatternTestCases(ValidatorTest):
         results = validate_string(attack_pattern_string, self.options)
         self.assertEqual(results.is_valid, False)
 
-        self.assertTrueWithOptions(attack_pattern_string, enabled='custom-property-prefix-lax')
-        self.assertFalseWithOptions(attack_pattern_string, disabled='custom-property-prefix-lax')
-        self.check_ignore(attack_pattern_string, 'custom-property-prefix')
+        self.assertTrueWithOptions(attack_pattern_string, enabled='custom-prefix-lax')
+        self.assertFalseWithOptions(attack_pattern_string, disabled='custom-prefix-lax')
+        self.check_ignore(attack_pattern_string, 'custom-prefix')
 
     def test_valid_property_prefix(self):
         attack_pattern = copy.deepcopy(self.valid_attack_pattern)

--- a/stix2validator/test/custom_obj_tests.py
+++ b/stix2validator/test/custom_obj_tests.py
@@ -64,8 +64,8 @@ class CustomObjectTestCases(ValidatorTest):
         results = validate_string(custom_obj_string, self.options)
         self.assertEqual(results.is_valid, False)
 
-        self.assertFalseWithOptions(custom_obj_string, enabled='custom-object-prefix-lax')
-        self.assertFalseWithOptions(custom_obj_string, disabled='custom-object-prefix-lax')
+        self.assertFalseWithOptions(custom_obj_string, enabled='custom-prefix-lax')
+        self.assertFalseWithOptions(custom_obj_string, disabled='custom-prefix-lax')
 
     def test_invalid_type_name_lax(self):
         custom_obj = copy.deepcopy(self.valid_custom_object)
@@ -75,8 +75,8 @@ class CustomObjectTestCases(ValidatorTest):
         results = validate_string(custom_obj_string, self.options)
         self.assertEqual(results.is_valid, False)
 
-        self.assertTrueWithOptions(custom_obj_string, enabled='custom-object-prefix-lax')
-        self.check_ignore(custom_obj_string, 'custom-object-prefix')
+        self.assertTrueWithOptions(custom_obj_string, enabled='custom-prefix-lax')
+        self.check_ignore(custom_obj_string, 'custom-prefix')
 
     def test_valid_type_name(self):
         custom_obj = copy.deepcopy(self.valid_custom_object)

--- a/stix2validator/test/indicator_tests.py
+++ b/stix2validator/test/indicator_tests.py
@@ -140,6 +140,31 @@ class IndicatorTestCases(ValidatorTest):
         indicator['pattern'] = """[file:hashes."SHA-256" = 'aec070645fe53ee3b3763059376134f058cc337247c978add178b6ccdfb0019f']"""
         self.assertFalseWithOptions(json.dumps(indicator))
 
+    def test_pattern_custom_invalid_format(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator['pattern'] = """[ab:yz = 'something']"""
+        self.assertFalseWithOptions(json.dumps(indicator))
+
+    def test_pattern_custom_object_noprefix(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator['pattern'] = """[foo:name = 'something']"""
+        self.assertFalseWithOptions(json.dumps(indicator))
+
+        self.check_ignore(json.dumps(indicator), 'custom-prefix,custom-prefix-lax')
+        self.assertFalseWithOptions(json.dumps(indicator), disabled='custom-prefix')
+
+    def test_pattern_custom_object_prefix_strict(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator['pattern'] = """[x-x-foo:x_x_name = 'something']"""
+        self.assertTrueWithOptions(json.dumps(indicator))
+
+        self.assertFalseWithOptions(json.dumps(indicator), strict_types=True)
+
+    def test_pattern_custom_object_prefix_lax(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator['pattern'] = """[x-foo":x_name = 'something']"""
+        self.check_ignore(json.dumps(indicator), 'custom-prefix')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/stix2validator/test/observed_data_tests.py
+++ b/stix2validator/test/observed_data_tests.py
@@ -318,7 +318,7 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(json.dumps(observed_data))
 
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-object-prefix,custom-observable-object-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
 
         observed_data['objects']['0']['type'] = "x-c-foo"
         self.assertTrueWithOptions(json.dumps(observed_data))
@@ -328,13 +328,13 @@ class ObservedDataTestCases(ValidatorTest):
         observed_data = copy.deepcopy(self.valid_observed_data)
         observed_data['objects']['0']['type'] = "foo"
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-object-prefix')
+                                    disabled='custom-prefix')
         observed_data['objects']['0']['type'] = "x-foo"
         self.assertFalseWithOptions(json.dumps(observed_data))
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-object-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-object-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_extensions(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -345,7 +345,7 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(observed_data)
 
         self.check_ignore(observed_data,
-                          'custom-object-extension-prefix,custom-object-extension-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
 
     def test_observable_object_extensions_prefix_lax(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -353,7 +353,7 @@ class ObservedDataTestCases(ValidatorTest):
             "foo": "bar"
         }
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-object-extension-prefix')
+                                    disabled='custom-prefix')
 
         del observed_data['objects']['0']['extensions']['foobar']
         observed_data['objects']['0']['extensions']['x-foobar'] = {
@@ -361,9 +361,9 @@ class ObservedDataTestCases(ValidatorTest):
         }
         self.assertFalseWithOptions(json.dumps(observed_data))
         self.check_ignore(json.dumps(observed_data),
-                          'custom-object-extension-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-object-extension-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -372,22 +372,22 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(observed_data)
 
         self.check_ignore(observed_data,
-                          'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
         self.assertFalseWithOptions(observed_data,
-                                    disabled='custom-observable-properties-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_custom_properties_lax(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
         observed_data['objects']['0']['foo'] = "bar"
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix')
+                                    disabled='custom-prefix')
 
         del observed_data['objects']['0']['foo']
         observed_data['objects']['0']['x_foo'] = "bar"
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-properties-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_extension_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -396,20 +396,20 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(observed_data)
 
         self.check_ignore(observed_data,
-                          'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
 
     def test_observable_object_extension_custom_properties_lax(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
         observed_data['objects']['0']['extensions']['archive-ext']['foo'] = "bar"
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix')
+                                    disabled='custom-prefix')
 
         del observed_data['objects']['0']['extensions']['archive-ext']['foo']
         observed_data['objects']['0']['extensions']['archive-ext']['x_foo'] = "bar"
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-properties-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_embedded_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -424,7 +424,7 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(observed_data)
 
         self.check_ignore(observed_data,
-                          'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
 
     def test_observable_object_embedded_custom_properties_lax(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -436,14 +436,14 @@ class ObservedDataTestCases(ValidatorTest):
             }
         }
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix')
+                                    disabled='custom-prefix')
 
         del observed_data['objects']['2']['x509_v3_extensions']['foo']
         observed_data['objects']['2']['x509_v3_extensions']['x_foo'] = "bar"
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-properties-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_embedded_dict_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -463,7 +463,7 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(observed_data)
 
         self.check_ignore(observed_data,
-                          'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
 
     def test_observable_object_embedded_dict_custom_properties_lax(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -480,14 +480,14 @@ class ObservedDataTestCases(ValidatorTest):
             ]
         }
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix')
+                                    disabled='custom-prefix')
 
         del observed_data['objects']['2']['values'][0]['foo']
         observed_data['objects']['2']['values'][0]['x_foo'] = "bar"
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-properties-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_extension_embedded_custom_properties(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -504,7 +504,7 @@ class ObservedDataTestCases(ValidatorTest):
         self.assertFalseWithOptions(observed_data)
 
         self.check_ignore(observed_data,
-                          'custom-observable-properties-prefix,custom-observable-properties-prefix-lax')
+                          'custom-prefix,custom-prefix-lax')
 
     def test_observable_object_extension_embedded_custom_properties_lax(self):
         observed_data = copy.deepcopy(self.valid_observed_data)
@@ -518,14 +518,14 @@ class ObservedDataTestCases(ValidatorTest):
               ]
         }
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix')
+                                    disabled='custom-prefix')
 
         del observed_data['objects']['0']['extensions']['ntfs-ext']['alternate_data_streams'][0]['foo']
         observed_data['objects']['0']['extensions']['ntfs-ext']['alternate_data_streams'][0]['x_foo'] = "bar"
         self.check_ignore(json.dumps(observed_data),
-                          'custom-observable-properties-prefix')
+                          'custom-prefix')
         self.assertFalseWithOptions(json.dumps(observed_data),
-                                    disabled='custom-observable-properties-prefix-lax')
+                                    disabled='custom-prefix-lax')
 
     def test_observable_object_property_reference(self):
         observed_data = copy.deepcopy(self.valid_observed_data)

--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -29,6 +29,7 @@ class CustomDraft4Validator(Draft4Validator):
                                                     format_checker)
         self.musts_list = musts.list_musts(options)
         self.shoulds_list = shoulds.list_shoulds(options)
+        self.options = options
 
     def iter_errors_more(self, instance, check_musts=True):
         """Perform additional validation not possible merely with JSON schemas.
@@ -52,7 +53,10 @@ class CustomDraft4Validator(Draft4Validator):
 
         # Perform validation
         for v_function in validators:
-            result = v_function(instance)
+            try:
+                result = v_function(instance)
+            except TypeError:
+                result = v_function(instance, self.options)
             if isinstance(result, Iterable):
                 for x in result:
                     yield x


### PR DESCRIPTION
Does not check properties of extensions or embedded objects. That will be possible once `stix2patterns` has been updated so the `inspect()` method gives more granular details.

Note that this PR removes some check codes; `custom-property-prefix`, `custom-observable-object-prefix,` `custom-object-extension-prefix`, `custom-observable-properties-prefix`, and their `-lax` siblings have been replaced with `custom-prefix` and `custom-prefix-lax`.

Fix #23.