### PR TITLE
unpin jsonschema version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_version():
 install_requires = [
     'appdirs',
     'colorama',
-    'jsonschema==2.5.1',
+    'jsonschema>=2.5.1',
     'python-dateutil',
     'requests',
     'requests_cache',


### PR DESCRIPTION
I have run into an issue where my project requires newer `jsonschema` than stix validator had pinned in its dependencies. To prevent having rerelease `stix2-validator` every time `jsonschema` makes a backward compatible update that someone wants to use as well as `stix2-validator` I suggest allowing any version that fulfills minimal `stix2-validator`requirements.