### PR TITLE
Remove checks 229 and 242

### DIFF
--- a/docs/best-practices.rst
+++ b/docs/best-practices.rst
@@ -142,17 +142,11 @@ Check Codes - STIX 2.1
 |  228   | malware-capabilities        | certain property values are from the   |
 |        |                             | malware-capabilities vocabulary        |
 +--------+-----------------------------+----------------------------------------+
-|  229   | opinion                     | certain property values are from the   |
-|        |                             | opinion vocabulary                     |
-+--------+-----------------------------+----------------------------------------+
 |  230   | processor-architecture      | certain property values are from the   |
 |        |                             | processor-architecture vocabulary      |
 +--------+-----------------------------+----------------------------------------+
 |  241   | hash-algo                   | certain property values are from the   |
 |        |                             | hash-algo vocabulary                   |
-+--------+-----------------------------+----------------------------------------+
-|  242   | encryption-algo             | certain property values are from the   |
-|        |                             | encryption-algo vocabulary             |
 +--------+-----------------------------+----------------------------------------+
 |  243   | windows-pebinary-type       | certain property values are from the   |
 |        |                             | windows-pebinary-type vocabulary       |

--- a/stix2validator/util.py
+++ b/stix2validator/util.py
@@ -98,14 +98,10 @@ https://stix2-validator.readthedocs.io/en/latest/best-practices.html.
 |      |                             | infrastructure vocabulary              |
 | 228  | malware-capabilities        | certain property values are from the   |
 |      |                             | malware-capabilities vocabulary        |
-| 229  | opinion                     | certain property values are from the   |
-|      |                             | opinion vocabulary                     |
 | 230  | processor-architecture      | certain property values are from the   |
 |      |                             | processor-architecture vocabulary      |
 | 241  | hash-algo                   | certain property values are from the   |
 |      |                             | hash-algo vocabulary                   |
-| 242  | encryption-algo             | certain property values are from the   |
-|      |                             | encryption-algo vocabulary             |
 | 243  | windows-pebinary-type       | certain property values are from the   |
 |      |                             | windows-pebinary-type vocabulary       |
 | 244  | account-type                | certain property values are from the   |

--- a/stix2validator/v21/enums.py
+++ b/stix2validator/v21/enums.py
@@ -188,13 +188,6 @@ MALWARE_CAPABILITIES_OV = [
     "steals-authentication-credentials",
     "violates-system-operational-integrity",
 ]
-OPINION_OV = [
-    "strongly-disagree",
-    "disagree",
-    "neutral",
-    "agree",
-    "strongly-agree",
-]
 PROCESSOR_ARCHITECTURE_OV = [
     "alpha",
     "arm",
@@ -307,30 +300,6 @@ HASH_ALGO_OV = [
     "ssdeep",
     "WHIRLPOOL",
 ]
-ENCRYPTION_ALGO_OV = [
-    "AES128-ECB",
-    "AES128-CBC",
-    "AES128-CFB",
-    "AES128-COFB",
-    "AES128-CTR",
-    "AES128-XTS",
-    "AES128-GCM",
-    "AES-256-GCM",
-    "Salsa20",
-    "Salsa12",
-    "Salsa8",
-    "ChaCha20-Poly1305",
-    "ChaCha20",
-    "DES-CBC",
-    "3DES-CBC",
-    "DES-EBC",
-    "3DES-EBC",
-    "CAST128-CBC",
-    "CAST256-CBC",
-    "RSA",
-    "DSA",
-    "mime-type-indicated",
-]
 WINDOWS_PEBINARY_TYPE_OV = [
     "exe",
     "dll",
@@ -376,9 +345,6 @@ ATTACK_RESOURCE_LEVEL_USES = {
 COURSE_OF_ACTION_TYPE_USES = {
     "course-of-action": ["action_type"],
 }
-ENCRYPTION_ALGO_USES = {
-    "artifact": ["encryption_algorithm"],
-}
 GROUPING_CONTEXT_USES = {
     "grouping": ["context"],
 }
@@ -413,9 +379,6 @@ REGION_USES = {
 }
 MALWARE_TYPE_USES = {
     "malware": ["malware_types"],
-}
-OPINION_USES = {
-    "opinion": ["opinion"],
 }
 PROCESSOR_ARCHITECTURE_USES = {
     "malware": ["architecture_execution_envs"],
@@ -2030,7 +1993,6 @@ TIMESTAMP_COMPARE_OBSERVABLE = {
 # Mapping of official STIX objects to their open-vocab properties
 VOCAB_PROPERTIES = {
     "artifact": [
-        'encryption_algorithm',
         'hashes'
     ],
     "course-of-action": [
@@ -2068,9 +2030,6 @@ VOCAB_PROPERTIES = {
     ],
     "ntfs-ext": [
         'hashes',
-    ],
-    "opinion": [
-        'opinion',
     ],
     "report": [
         'report_types',
@@ -2149,10 +2108,8 @@ CHECK_CODES = {
     '226': 'implementation-languages',
     '227': 'infrastructure-types',
     '228': 'malware-capabilities',
-    '229': 'opinion',
     '230': 'processor-architecture',
     '241': 'hash-algo',
-    '242': 'encryption-algo',
     '243': 'windows-pebinary-type',
     '244': 'account-type',
     '270': 'all-external-sources',

--- a/stix2validator/v21/shoulds.py
+++ b/stix2validator/v21/shoulds.py
@@ -273,11 +273,6 @@ def vocab_course_of_action_type(instance):
                        'course-of-action-type')
 
 
-def vocab_encryption_algo(instance):
-    return check_vocab(instance, "ENCRYPTION_ALGO",
-                       'encryption-algo')
-
-
 def vocab_grouping_context(instance):
     return check_vocab(instance, "GROUPING_CONTEXT",
                        'grouping-context')
@@ -316,11 +311,6 @@ def vocab_malware_types(instance):
 def vocab_malware_capabilities(instance):
     return check_vocab(instance, "MALWARE_CAPABILITIES",
                        'malware-capabilities')
-
-
-def vocab_opinion(instance):
-    return check_vocab(instance, "OPINION",
-                       'opinion')
 
 
 def vocab_processor_architecture(instance):
@@ -1283,7 +1273,6 @@ CHECKS = {
         vocab_implementation_languages,
         vocab_infrastructure_types,
         vocab_malware_capabilities,
-        vocab_opinion,
         vocab_processor_architecture,
         vocab_identity_class,
         vocab_indicator_types,
@@ -1348,7 +1337,6 @@ CHECKS = {
         vocab_implementation_languages,
         vocab_infrastructure_types,
         vocab_malware_capabilities,
-        vocab_opinion,
         vocab_processor_architecture,
         vocab_identity_class,
         vocab_indicator_types,
@@ -1383,7 +1371,6 @@ CHECKS = {
         vocab_implementation_languages,
         vocab_infrastructure_types,
         vocab_malware_capabilities,
-        vocab_opinion,
         vocab_processor_architecture,
         vocab_identity_class,
         vocab_indicator_types,
@@ -1402,12 +1389,10 @@ CHECKS = {
     'attack-motivation': vocab_attack_motivation,
     'attack-resource-level': vocab_attack_resource_level,
     'course-of-action-type': vocab_course_of_action_type,
-    'encryption-algo': vocab_encryption_algo,
     'grouping-context': vocab_grouping_context,
     'implementation-languages': vocab_implementation_languages,
     'infrastructure-types': vocab_infrastructure_types,
     'malware-capabilities': vocab_malware_capabilities,
-    'opinion': vocab_opinion,
     'processor-architecture': vocab_processor_architecture,
     'identity-class': vocab_identity_class,
     'indicator-types': vocab_indicator_types,


### PR DESCRIPTION
These treat opinion-emum and encryption_algo_enum as if they were open
vocabs instead.

Fixes #104.