### PR TITLE
Ensure emails are formatted correctly.

### DIFF
--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -5,6 +5,7 @@ from collections import Iterable
 import io
 from itertools import chain
 import os
+import re
 import sys
 
 from jsonschema import Draft7Validator, RefResolver, draft7_format_checker
@@ -28,6 +29,9 @@ try:
 except NameError:
     # Python 2
     FileNotFoundError = IOError
+
+
+EMAIL_RE = re.compile(r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)')
 
 
 def _is_iterable_non_string(val):
@@ -525,6 +529,14 @@ def ref_store(validator, ref, instance, schema):
 
 
 STIXValidator = extend(Draft7Validator, {'$ref': ref_store})
+
+
+# Built-in checker only ensures emails contain an '@'; we want a more robust check
+@draft7_format_checker.checks('email')
+def is_email(instance):
+    if not isinstance(instance, string_types):
+        return True
+    return EMAIL_RE.match(instance)
 
 
 def load_validator(schema_path, schema):


### PR DESCRIPTION
`jsonschema`'s built-in email format checker only ensures it contains the '@' character. We want a more robust check. Moved it here instead of schemas to rely on JSON Schema spec's 'email' format for users of other JSON Schema validators in other languages.