### PR TITLE
Add 'swid' as a legal property of the 2.1 'software' SCO.

### DIFF
--- a/stix2validator/v21/enums.py
+++ b/stix2validator/v21/enums.py
@@ -1163,6 +1163,7 @@ OBSERVABLE_PROPERTIES = {
         'extensions',
         'name',
         'cpe',
+        'swid',
         'languages',
         'vendor',
         'version',


### PR DESCRIPTION
Fixes #132 .