### PR TITLE
Allow  property names on custom SCOs in patterns

### DIFF
--- a/stix2validator/test/v20/indicator_tests.py
+++ b/stix2validator/test/v20/indicator_tests.py
@@ -220,3 +220,10 @@ class IndicatorTestCases(ValidatorTest):
         results = validate_parsed_json(objects, options)
         assert results[0].is_valid
         assert not results[1].is_valid
+
+    def test_pattern_custom_sco(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator["pattern"] = "[x-foo-bar:bizz MATCHES 'buzz']"
+
+        self.assertTrueWithOptions(indicator)
+        self.assertTrueWithOptions(indicator, strict_properties=True)

--- a/stix2validator/test/v21/indicator_tests.py
+++ b/stix2validator/test/v21/indicator_tests.py
@@ -273,3 +273,10 @@ class IndicatorTestCases(ValidatorTest):
         del indicator["pattern_type"]
 
         self.assertFalseWithOptions(indicator)
+
+    def test_pattern_custom_sco(self):
+        indicator = copy.deepcopy(self.valid_indicator)
+        indicator["pattern"] = "[x-foo-bar:bizz MATCHES 'buzz']"
+
+        self.assertTrueWithOptions(indicator)
+        self.assertTrueWithOptions(indicator, strict_properties=True)

--- a/stix2validator/v20/musts.py
+++ b/stix2validator/v20/musts.py
@@ -374,6 +374,8 @@ def patterns(instance, options):
             elif not property_format_re.match(prop):
                 yield PatternError("'%s' is not a valid observable property name"
                                    % prop, instance['id'])
+            elif objtype not in enums.OBSERVABLE_TYPES:
+                continue  # custom SCOs aren't required to use x_ prefix on properties
             elif (all(x not in options.disabled for x in ['all', 'format-checks', 'custom-prefix']) and
                   not CUSTOM_PROPERTY_PREFIX_RE.match(prop)):
                 yield PatternError("Cyber Observable Object custom property '%s' "

--- a/stix2validator/v21/musts.py
+++ b/stix2validator/v21/musts.py
@@ -461,6 +461,8 @@ def patterns(instance, options):
             elif not PROPERTY_FORMAT_RE.match(prop):
                 yield PatternError("'%s' is not a valid observable property name"
                                    % prop, instance['id'])
+            elif objtype not in enums.OBSERVABLE_TYPES:
+                continue  # custom SCOs aren't required to use x_ prefix on properties
             elif (all(x not in options.disabled for x in ['all', 'format-checks', 'custom-prefix']) and
                   not CUSTOM_PROPERTY_PREFIX_RE.match(prop)):
                 yield PatternError("Cyber Observable Object custom property '%s' "


### PR DESCRIPTION
Property names on custom SCOs don't have to use the 'x_' prefix, though they may.