### PR TITLE
Reword malware.is_family error if it's not boolean

### DIFF
--- a/stix2validator/errors.py
+++ b/stix2validator/errors.py
@@ -208,6 +208,10 @@ def pretty_error(error, verbose=False):
                         'end' in error.instance):
                     msg = "If the 'is_active' property is true, then the "\
                           "'end' property must not be included."
+            elif 'type' in error.instance and error.instance['type'] == 'malware':
+                if ('is_family' in error.instance and
+                        not isinstance(error.instance['is_family'], bool)):
+                    msg = "is_family: 'true' is not of type 'boolean'"
             else:
                 raise TypeError
         except TypeError:

--- a/stix2validator/test/v21/malware_tests.py
+++ b/stix2validator/test/v21/malware_tests.py
@@ -51,3 +51,8 @@ class MalwareTestCases(ValidatorTest):
         malware['malware_types'] += "ransom ware"
         self.assertFalseWithOptions(malware,
                                     disabled='malware-types')
+
+    def test_vocab_malware_is_family_boolean(self):
+        malware = copy.deepcopy(self.valid_malware)
+        malware['is_family'] = "true"
+        self.assertFalseWithOptions(malware)


### PR DESCRIPTION
Reference: https://github.com/oasis-open/cti-stix2-json-schemas/issues/134