### PR TITLE
Fix timestamp comparisons for CS03

### DIFF
--- a/stix2validator/test/v21/network_traffic_tests.py
+++ b/stix2validator/test/v21/network_traffic_tests.py
@@ -119,11 +119,11 @@ class ObservedDataTestCases(ValidatorTest):
     def test_invalid_start_end_time(self):
         net_traffic = copy.deepcopy(self.valid_net_traffic)
         net_traffic['start'] = "2016-04-06T20:06:37.000Z"
-        net_traffic['end'] = "2016-04-06T20:06:37.000Z"
-        self.assertFalseWithOptions(net_traffic)
-
         net_traffic['end'] = "2016-01-01T00:00:00.000Z"
         self.assertFalseWithOptions(net_traffic)
+
+        net_traffic['end'] = "2016-04-06T20:06:37.000Z"
+        self.assertTrueWithOptions(net_traffic)
 
         net_traffic['end'] = "2016-05-07T20:06:37.000Z"
         self.assertTrueWithOptions(net_traffic)

--- a/stix2validator/test/v21/sighting_tests.py
+++ b/stix2validator/test/v21/sighting_tests.py
@@ -44,11 +44,11 @@ class IdentityTestCases(ValidatorTest):
     def test_invalid_seen_time(self):
         sighting = copy.deepcopy(self.valid_sighting)
         sighting['first_seen'] = "2016-04-06T20:06:37.000Z"
-        sighting['last_seen'] = "2016-04-06T20:06:37.000Z"
-        self.assertFalseWithOptions(sighting)
-
         sighting['last_seen'] = "2016-01-01T00:00:00.000Z"
         self.assertFalseWithOptions(sighting)
+
+        sighting['last_seen'] = "2016-04-06T20:06:37.000Z"
+        self.assertTrueWithOptions(sighting)
 
         sighting['last_seen'] = "2016-05-07T20:06:37.000Z"
         self.assertTrueWithOptions(sighting)

--- a/stix2validator/v21/enums.py
+++ b/stix2validator/v21/enums.py
@@ -2041,7 +2041,7 @@ TIMESTAMP_COMPARE = {
         ('stop_time', 'gt', 'start_time'),
     ],
     "sighting": [
-        ('last_seen', 'gt', 'first_seen'),
+        ('last_seen', 'ge', 'first_seen'),
     ],
     'threat-actor': [
         ('last_seen', 'ge', 'first_seen')
@@ -2051,7 +2051,7 @@ TIMESTAMP_COMPARE = {
 # Mapping of STIX Object timestamp properties with a comparison requirement
 TIMESTAMP_COMPARE_OBSERVABLE = {
     "network-traffic": [
-        ('end', 'gt', 'start'),
+        ('end', 'ge', 'start'),
     ],
 }
 


### PR DESCRIPTION
Two sets of timestamp properties were change to allow both properties in the set to have the exact same timestamp:
- Sighting: first_seen and last_seen
- Network Traffic: start and end