### PR TITLE
Update for extension schemas

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -85,7 +85,7 @@ Additional Schemas
 The validator uses the `STIX 2 JSON schemas <https://github.com/oasis-open/cti-stix2-
 json-schemas>`_ as the basis for its validation, but you can also validate with
 your own additional schemas. This can help if you want to validate STIX content
-using custom objects, properties, observables, or extensions.
+using extensions or (now deprecated) custom objects, properties, or observables.
 
 To do this use the ``--schemas`` argument:
 
@@ -106,10 +106,22 @@ or in Python, using ``schema_dir``:
 You can see some examples of custom schemas `here <https://github.com/oasis-open/cti-stix-validator/tree/master/stix2validator/test/v21/test_schemas>`_.
 
 .. note::
-  The schema's filename must match the type name of the STIX object type so the
-  validator can parse it correctly. For example, a schema defining a new
-  extension on Indicators should be named `indicator.json`. A schema defining a
-  new object type, "my-cool-thing", would need to be named `my-cool-thing.json`.
+  The schema's filename must match the extension definition id of the extension
+  it describes so the validator can apply it correctly. For example, a schema
+  defining a new extension with an id of
+  ``extension-definition--bfaece0b-efa6-4dfa-8248-3d340e2030f8`` should be named
+  `extension-definition--bfaece0b-efa6-4dfa-8248-3d340e2030f8.json`.
 
 .. note::
-  If you want to add a custom property to an existing object type, your custom schema only needs to contain that property; the validator's built-in schemas are still checked against and will handle the rest.
+  Custom objects and properties using the ``x_`` and ``x-`` prefixes have been
+  deprecated in STIX 2.1. However, if you need a schema for validating them, the
+  validator can parse it as long as the schema's filename matches the type name
+  of the STIX object type it should apply to. For example, a schema defining a
+  new property on Indicators should be named ``indicator.json``. A schema
+  defining a new object type, “my-cool-thing”, would need to be named
+  ``my-cool-thing.json``.
+
+.. note::
+  When using additional schemas, the validator's built-in schemas are still
+  checked against. Thus custom schemas only need to contain the properties that
+  differ from the standard.

--- a/stix2validator/errors.py
+++ b/stix2validator/errors.py
@@ -207,6 +207,10 @@ def pretty_error(error, verbose=False):
                           "and 'definition' properties with a valid marking "\
                           "definition, or use an extension and the properties "\
                           "it requires"
+                    if verbose:
+                        msg += remove_u(error.message)
+                    else:
+                        msg += " (for more details use --verbose)"
             elif 'type' in error.instance and error.instance['type'] == 'file':
                 if (('is_encrypted' not in error.instance or
                         error.instance['is_encrypted'] is False) and

--- a/stix2validator/errors.py
+++ b/stix2validator/errors.py
@@ -208,7 +208,7 @@ def pretty_error(error, verbose=False):
                           "definition, or use an extension and the properties "\
                           "it requires"
                     if verbose:
-                        msg += remove_u(error.message)
+                        msg += ".\nComplete error: {}".format(remove_u(error.message))
                     else:
                         msg += " (for more details use --verbose)"
             elif 'type' in error.instance and error.instance['type'] == 'file':

--- a/stix2validator/errors.py
+++ b/stix2validator/errors.py
@@ -203,9 +203,10 @@ def pretty_error(error, verbose=False):
                     msg = "'definition' must contain a valid statement, TLP, or "\
                           "custom marking definition"
                 else:
-                    msg = "marking definitions must use a valid extension, or "\
-                          "the 'definition_type' and 'definition' properties "\
-                          "with a valid marking definition"
+                    msg = "marking definitions must use the 'definition_type' "\
+                          "and 'definition' properties with a valid marking "\
+                          "definition, or use an extension and the properties "\
+                          "it requires"
             elif 'type' in error.instance and error.instance['type'] == 'file':
                 if (('is_encrypted' not in error.instance or
                         error.instance['is_encrypted'] is False) and

--- a/stix2validator/output.py
+++ b/stix2validator/output.py
@@ -56,7 +56,7 @@ def info(msg):
     if not _VERBOSE:
         return
 
-    logger.debug("[-] %s" % msg)
+    logger.info("[-] %s" % msg)
 
 
 def print_level(log_function, fmt, level, *args):

--- a/stix2validator/test/v21/indicator_tests.py
+++ b/stix2validator/test/v21/indicator_tests.py
@@ -226,7 +226,7 @@ class IndicatorTestCases(ValidatorTest):
         self.assertTrueWithOptions(indicator, schema_dir=self.custom_schemas)
 
     def test_additional_schema_custom_type(self):
-        # no schema exists for this type
+        # no schema exists for this type or extension
         new_obj = {
             "type": "x-type",
             "spec_version": "2.1",

--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -788,8 +788,11 @@ def _schema_validate(obj, options, bundle_version=None):
             extension_errors = _get_error_generator(ext, obj, options.schema_dir, version, default=core_schema)
             if extension_errors:
                 error_gens.append((extension_errors, error_prefix))
-    elif obj.get('extensions'):
-        output.info("{} contains extensions but no additional schemas provided with the --schemas option.".format(obj['id']))
+    elif options.verbose and obj.get('extensions'):
+        keys = obj.get('extensions', {}).keys()
+        if any(key.startswith('extension-definition--') for key in keys):
+            output.info("{} contains extensions but no additional schemas provided "
+                        "with the --schemas option.".format(obj['id']))
 
     # Validate each cyber observable object separately
     if obj['type'] == 'observed-data' and 'objects' in obj:

--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -575,7 +575,7 @@ def find_schema(schema_dir, name):
     """
     schema_filename = name + '.json'
 
-    for root, dirnames, filenames in os.walk(schema_dir):
+    for root, dirnames, filenames in os.walk(schema_dir, followlinks=True):
         if "examples" in root:
             continue
         if schema_filename in filenames:

--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -788,6 +788,8 @@ def _schema_validate(obj, options, bundle_version=None):
             extension_errors = _get_error_generator(ext, obj, options.schema_dir, version, default=core_schema)
             if extension_errors:
                 error_gens.append((extension_errors, error_prefix))
+    elif obj.get('extensions'):
+        output.info("{} contains extensions but no additional schemas provided with the --schemas option.".format(obj['id']))
 
     # Validate each cyber observable object separately
     if obj['type'] == 'observed-data' and 'objects' in obj:

--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -631,14 +631,17 @@ def _get_error_generator(name, obj, schema_dir=None, version=DEFAULT_VER, defaul
         schema_path = find_schema(schema_dir, name)
         schema = load_schema(schema_path)
     except (KeyError, TypeError):
-        # Assume a custom object with no schema
+        # Assume a custom object or extension with no schema
         try:
             schema_path = find_schema(schema_dir, default)
             schema = load_schema(schema_path)
         except (KeyError, TypeError):
             # Only raise an error when checking against default schemas, not custom
             if default_path is False:
+                if 'extension-definition--' in name:
+                    output.info("Could not find schema for {} so it will only be validated against the default schema.".format(name))
                 return None
+
             if schema_path is None:
                 raise SchemaInvalidError("Cannot locate a schema for the object's "
                                          "type, nor the base schema ({}.json).".format(default))


### PR DESCRIPTION
- Allow symlinks to folders in the directory given to the `--schemas` option.
- Revise documentation on using additional schemas.
- Revise an error message that may come up when using a schema for an extension and failing its validation.