### PR TITLE
Remove the attrs constraint added by #191

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ install_requires = [
     'requests_cache',
     'simplejson',
     'stix2-patterns>=0.4.1',
-    'attrs<22.0,>21.2',
 ]
 
 setup(


### PR DESCRIPTION
Can this constraint be removed if there isn't a clear dependency or use case for the constraint?
The attrs constraint was added in #191 but the stix2-validator does not use that package directly.

In that delta the jsonschema package version is modified. The latest release of the jsonschema package required attrs>=17.4.0,  https://github.com/python-jsonschema/jsonschema/blob/v4.17.3/pyproject.toml#L35

The next release of the jsonschema package will require attrs >= 22.2.0. The current constraint will prevent users from being able to upgrade their jsonschema library when that is released.

