### PR TITLE
Fix pre-commit and packaging on systems with updated dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         exclude: ^stix2validator/(v20|v21)/assets/.*.csv$
     -   id: check-merge-conflict
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.8.4
+    rev: 5.0.4
     hooks:
     -   id: flake8
         name: Check project styling

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ passenv = GITHUB_*
 [testenv:packaging]
 deps =
   twine
+  setuptools
+  wheel
 commands =
   python setup.py sdist bdist_wheel --universal
   twine check dist/*


### PR DESCRIPTION
Changes:
- Upgrade flake8 to support modern importlib-metadata
- Add explicit dependency to setuptools and wheel to the packaging task

Without these, a clean host virtual env with python 3.12 raises the following when launching `pre-commit`:
```
self._load_entrypoint_plugins()
  File "/Users/user/.cache/pre-commit/repoc7dbap5o/py_env-python3.12/lib/python3.12/site-packages/flake8/plugins/manager.py", line 261, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
``` 

And packaging fails with:
```
Traceback (most recent call last):
  File "/Users/user/External/cti-stix-validator/setup.py", line 4, in <module>
    from setuptools import find_packages, setup
ModuleNotFoundError: No module named 'setuptools'
```

The virtual env and tox was installed and run using the following commands on a system with python 3.12:
```
python3 -m venv venv
source venv/bin/activate
pip install tox
tox
```