### PR TITLE
Run latest Python tests on Windows

### DIFF
--- a/.github/workflows/python-ci-tests.yml
+++ b/.github/workflows/python-ci-tests.yml
@@ -6,10 +6,20 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+          - os: windows-latest
+            python-version: '3.8'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.11'
 
     name: Python ${{ matrix.python-version }} Build
     steps:


### PR DESCRIPTION
Since we do path manipulation when processing JSON files (functionality further exercised by this PR https://github.com/oasis-open/cti-stix-validator/pull/228), tests should run at least once on Windows to make sure that path manipulation works as expected.

CC @clenk 