### PR TITLE
Fix unicode errors when validating files

### DIFF
--- a/stix2validator/test/v21/misc_tests.py
+++ b/stix2validator/test/v21/misc_tests.py
@@ -20,6 +20,8 @@ IDENTITY = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                         'test_examples', 'identity.json')
 IDENTITY_CUSTOM = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                'test_examples', 'identity_custom.json')
+IDENTITY_UNICODE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                'test_examples', 'identity_unicode.json')
 INVALID_BRACES = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                               'test_examples', 'invalid_braces.json')
 INVALID_COMMA = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -69,6 +71,11 @@ def test_validate_file_warning(caplog):
 
     print_results(results)
     assert re.search("Custom property .+ should ", caplog.text)
+
+
+def test_validate_file_unicode(caplog):
+    results = validate_file(IDENTITY_UNICODE)
+    assert results.is_valid
 
 
 def test_validate_file_invalid_brace(caplog):

--- a/stix2validator/test/v21/test_examples/identity_unicode.json
+++ b/stix2validator/test/v21/test_examples/identity_unicode.json
@@ -1,0 +1,9 @@
+{
+  "type": "identity",
+  "spec_version": "2.1",
+  "id": "identity--8c6af861-7b20-41ef-9b59-6344fd872a8f",
+  "created": "2016-08-08T15:50:10.983Z",
+  "modified": "2016-08-08T15:50:10.983Z",
+  "name": "Heizölrückstoßabdämpfung",
+  "identity_class": "organization"
+}

--- a/stix2validator/validator.py
+++ b/stix2validator/validator.py
@@ -453,7 +453,7 @@ def validate_file(fn, options=None):
         options = ValidationOptions(files=fn)
 
     try:
-        with open(fn) as instance_file:
+        with open(fn, encoding="utf-8") as instance_file:
             file_results.object_results = validate(instance_file, options)
 
     except Exception as ex:


### PR DESCRIPTION
Previously undetected because testing was only performed on systems where utf-8 is default.