### PR TITLE
Fix for issue #180 by Claude Code

### DIFF
--- a/docs/best-practices.rst
+++ b/docs/best-practices.rst
@@ -99,8 +99,8 @@ Mandatory Checks - STIX 2.1
 |                                 | RFC 5646 language code                 | language code.                         |
 +---------------------------------+----------------------------------------+----------------------------------------+
 | software_language               | the 'language' property of software    | The 'languages' property of object     |
-|                                 | objects is a valid ISO 639-2 language  | '<identifier>' contains an invalid     |
-|                                 | code                                   | code ('<lang>').                       |
+|                                 | objects is a valid RFC 5646 language   | '<identifier>' contains an invalid     |
+|                                 | code (ISO 639-2 accepted with warning) | code ('<lang>').                       |
 +---------------------------------+----------------------------------------+----------------------------------------+
 | patterns                        | that the syntax of the pattern of an   | '<object>' is not a valid observable   |
 |                                 | indicator is valid, and that objects   | type name                              |

--- a/stix2validator/test/v21/observed_data_tests.py
+++ b/stix2validator/test/v21/observed_data_tests.py
@@ -643,8 +643,40 @@ class ObservedDataTestCases(ValidatorTest):
         }
         self.assertFalseWithOptions(observed_data)
 
-        observed_data['languages'][0] = 'eng'
+        # Test with RFC 5646 language code (preferred)
+        observed_data['languages'][0] = 'en'
         self.assertTrueWithOptions(observed_data)
+
+    def test_software_language_iso639_compatibility(self):
+        """Test that ISO 639-2 codes are accepted with warnings for backward compatibility"""
+        import logging
+        import io
+        
+        # Capture log output
+        log_capture = io.StringIO()
+        handler = logging.StreamHandler(log_capture)
+        handler.setLevel(logging.WARNING)
+        logger = logging.getLogger('stix2validator.v21.musts')
+        logger.addHandler(handler)
+        logger.setLevel(logging.WARNING)
+        
+        observed_data = {
+            "type": "software",
+            "id": "software--ff1e0780-358c-5808-a8c7-d0fca4ef6ef4",
+            "name": "word",
+            "languages": ["eng"]  # ISO 639-2 code
+        }
+        
+        # Should be valid (backward compatibility)
+        self.assertTrueWithOptions(observed_data)
+        
+        # Should generate a warning
+        log_output = log_capture.getvalue()
+        self.assertIn("ISO 639-2 language code", log_output)
+        self.assertIn("RFC 5646 language codes are preferred", log_output)
+        
+        # Clean up
+        logger.removeHandler(handler)
 
     def test_software_cpe(self):
         observed_data = {

--- a/stix2validator/v21/musts.py
+++ b/stix2validator/v21/musts.py
@@ -411,16 +411,30 @@ def language(instance):
 
 @cyber_observable_check("2.1")
 def software_language(instance):
-    """Ensure the 'language' property of software objects is a valid ISO 639-2
-    language code.
+    """Ensure the 'language' property of software objects is a valid RFC 5646
+    language code. ISO 639-2 codes are accepted for backward compatibility
+    but will generate warnings.
     """
     if ('type' in instance and instance['type'] == 'software' and
             'languages' in instance):
         for lang in instance['languages']:
-            if lang not in enums.SOFTWARE_LANG_CODES:
+            if lang in enums.LANG_CODES:
+                # Valid RFC 5646 language code
+                continue
+            elif lang in enums.SOFTWARE_LANG_CODES:
+                # ISO 639-2 code - accept but warn
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.warning("The 'languages' property of object '%s' "
+                              "contains an ISO 639-2 language code ('%s'). "
+                              "RFC 5646 language codes are preferred for STIX 2.1. "
+                              "Consider updating to RFC 5646 format."
+                              % (instance['id'], lang))
+            else:
+                # Invalid language code
                 yield JSONError("The 'languages' property of object '%s' "
-                                "contains an invalid ISO 639-2 language "
-                                " code ('%s')."
+                                "contains an invalid language code ('%s'). "
+                                "Expected RFC 5646 language code."
                                 % (instance['id'], lang), instance['id'])
 
 


### PR DESCRIPTION
Issue #180 is rather lacking in detail, but it turns out that STIX 2.1 CS02 requires ISO639-2 language tags for the software object's languages property, while STIX 2.1 CS03 requires RFC 5646 language tags. See https://docs.oasis-open.org/cti/stix/v2.1/cs03/stix-v2.1-cs03.html#_jru33yeokrmh

The stix-validator currently requires ISO639-2 language tags in adherence to CS02, but should really check for RFC 5646. Since some people have probably already been working with the ISO language tags, I didn't want to make those suddenly fail, so they issue a warning rather than an error. In the future, this should switch to an error. 

I have been playing around with Claude Code, so I tried it on this issue. Here is Claude's PR description to go along with the fix:
Summary of Changes Made for Issue #180

  Issue Fixed: Software language validation in STIX 2.1 now uses RFC 5646 language codes instead of ISO 639-2
  codes, as required by the STIX 2.1 CS03 specification.

  Key Changes:

  1. Updated Validation Logic (stix2validator/v21/musts.py:413-438):
    - Changed primary validation from SOFTWARE_LANG_CODES (ISO 639-2) to LANG_CODES (RFC 5646)
    - Added backward compatibility for ISO 639-2 codes with deprecation warnings
    - Updated error messages to reference RFC 5646 standard
  2. Backward Compatibility:
    - ISO 639-2 codes (like 'eng', 'fra') are still accepted but generate warning messages
    - RFC 5646 codes (like 'en', 'en-US', 'fr-FR') are preferred and don't generate warnings
    - Invalid codes that don't match either standard still generate validation errors
  3. Updated Tests (stix2validator/test/v21/observed_data_tests.py):
    - Modified existing test to use RFC 5646 code ('en' instead of 'eng')
    - Added new test for backward compatibility warnings
    - Test validates that ISO 639-2 codes generate appropriate warning messages
  4. Updated Documentation (docs/best-practices.rst):
    - Updated description to reflect RFC 5646 standard with backward compatibility note

  Technical Implementation:

  - Primary validation: Uses enums.LANG_CODES (RFC 5646 format)
  - Backward compatibility: Checks enums.SOFTWARE_LANG_CODES (ISO 639-2 format) and logs warnings
  - Warning system: Uses Python logging to generate deprecation warnings for ISO 639-2 usage
  - STIX 2.0 unchanged: Only STIX 2.1 validation is affected; STIX 2.0 continues using ISO 639-2

  Examples:

  - Valid RFC 5646: 'en', 'en-US', 'zh-CN' (no warnings)
  - Valid but deprecated: 'eng', 'fra', 'deu' (accepted with warnings)
  - Invalid: 'xyz', 'invalid' (validation error)

  This implementation ensures compliance with STIX 2.1 CS03 requirements while maintaining backward compatibility
  for existing implementations using ISO 639-2 codes.